### PR TITLE
(Not to be pulled) Charset tests

### DIFF
--- a/tests/checker/__init__.py
+++ b/tests/checker/__init__.py
@@ -200,8 +200,6 @@ class LinkCheckTest (unittest.TestCase):
 
     def fail_unicode (self, msg):
         """Print encoded fail message."""
-        # XXX self.fail() only supports ascii
-        msg = msg.encode("ascii", "replace")
         self.fail(msg)
 
     def direct (self, url, resultlines, parts=None, recursionlevel=0,

--- a/tests/checker/data/charsets/cp1250.html
+++ b/tests/checker/data/charsets/cp1250.html
@@ -1,0 +1,3 @@
+<meta http-equiv="Content-Type" content="text/html; charset=cp1250">
+<a href="file.html">Žluťoučký kúň úpěl ďábelské ódy ůůůů</a>
+<img src="img.png" alt="Žluťoučký kúň úpěl ďábelské ódy ůůůů"/>

--- a/tests/checker/data/charsets/cp1250.html.result
+++ b/tests/checker/data/charsets/cp1250.html.result
@@ -1,0 +1,17 @@
+url file://%(curdir)s/%(datadir)s/charsets/cp1250.html
+cache key file://%(curdir)s/%(datadir)s/charsets/cp1250.html
+real url file://%(curdir)s/%(datadir)s/charsets/cp1250.html
+name %(datadir)s/charsets/cp1250.html
+valid
+
+url file.html
+cache key file://%(curdir)s/%(datadir)s/charsets/file.html
+real url file://%(curdir)s/%(datadir)s/charsets/file.html
+name Žluťoučký kúň úpěl ďábelské ódy ůůůů
+error
+
+url img.png
+cache key file://%(curdir)s/%(datadir)s/charsets/img.png
+real url file://%(curdir)s/%(datadir)s/charsets/img.png
+name Žluťoučký kúň úpěl ďábelské ódy ůůůů
+error

--- a/tests/checker/data/charsets/iso8859-2.html
+++ b/tests/checker/data/charsets/iso8859-2.html
@@ -1,0 +1,3 @@
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-2">
+<a href="file.html">Žluťoučký kúň úpěl ďábelské ódy ůůůů</a>
+<img src="img.png" alt="Žluťoučký kúň úpěl ďábelské ódy ůůůů"/>

--- a/tests/checker/data/charsets/iso8859-2.html.result
+++ b/tests/checker/data/charsets/iso8859-2.html.result
@@ -1,0 +1,17 @@
+url file://%(curdir)s/%(datadir)s/charsets/iso8859-2.html
+cache key file://%(curdir)s/%(datadir)s/charsets/iso8859-2.html
+real url file://%(curdir)s/%(datadir)s/charsets/iso8859-2.html
+name %(datadir)s/charsets/iso8859-2.html
+valid
+
+url file.html
+cache key file://%(curdir)s/%(datadir)s/charsets/file.html
+real url file://%(curdir)s/%(datadir)s/charsets/file.html
+name Žluťoučký kúň úpěl ďábelské ódy ůůůů
+error
+
+url img.png
+cache key file://%(curdir)s/%(datadir)s/charsets/img.png
+real url file://%(curdir)s/%(datadir)s/charsets/img.png
+name Žluťoučký kúň úpěl ďábelské ódy ůůůů
+error

--- a/tests/checker/data/charsets/utf8.html
+++ b/tests/checker/data/charsets/utf8.html
@@ -1,0 +1,3 @@
+<meta charset="utf-8">
+<a href="file.html">Žluťoučký kúň úpěl ďábelské ódy ůůůů</a>
+<img src="img.png" alt="Žluťoučký kúň úpěl ďábelské ódy ůůůů"/>

--- a/tests/checker/data/charsets/utf8.html.result
+++ b/tests/checker/data/charsets/utf8.html.result
@@ -1,0 +1,17 @@
+url file://%(curdir)s/%(datadir)s/charsets/utf8.html
+cache key file://%(curdir)s/%(datadir)s/charsets/utf8.html
+real url file://%(curdir)s/%(datadir)s/charsets/utf8.html
+name %(datadir)s/charsets/utf8.html
+valid
+
+url file.html
+cache key file://%(curdir)s/%(datadir)s/charsets/file.html
+real url file://%(curdir)s/%(datadir)s/charsets/file.html
+name Žluťoučký kúň úpěl ďábelské ódy ůůůů
+error
+
+url img.png
+cache key file://%(curdir)s/%(datadir)s/charsets/img.png
+real url file://%(curdir)s/%(datadir)s/charsets/img.png
+name Žluťoučký kúň úpěl ďábelské ódy ůůůů
+error

--- a/tests/checker/test_charsets.py
+++ b/tests/checker/test_charsets.py
@@ -1,0 +1,40 @@
+# -*- coding: iso-8859-1 -*-
+# Copyright (C) 2004-2014 Bastian Kleineidam
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Test html <base> tag parsing.
+"""
+from . import LinkCheckTest
+
+
+class TestBase (LinkCheckTest):
+    """
+    Test, if charset encoding is done right.
+    The linkchecker should translate the encoding
+    from the original source and show it on the terminal
+    in most readable form.
+    Check the tested files with browser - the link text
+    should look the same in all of them.
+    """
+
+    def test_utf8(self):
+        self.file_test("charsets/utf8.html")
+
+    def test_iso8859_2(self):
+        self.file_test("charsets/iso8859-2.html")
+
+    def test_cp1250(self):
+        self.file_test("charsets/cp1250.html")


### PR DESCRIPTION
So about the encoding. It doesn't work in current implementation of Linkchecker at all.
I would expect, it translates the encoding from the original one to the encoding of the terminal. Or it translates the characters to the form, that one could easily read. (Like `Zlutoucky kun upel dabelske ody uuuu`). It does neither of that. It just outputs the link name in original form on the terminal, which will lead to unreadable characters.

This PR is not meant to be pulled, but it could serve as reference before implementing character handling fixes (i.e. during the parser change).