### PR TITLE
(WIP) add Appveyor configuration for Windows testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+# AppVeyor.com is a Continuous Integration service to build and run tests under
+# Windows
+
+environment:
+    matrix:
+        - PYTHON_VERSION: "2.7"
+        - PYTHON_VERSION: "3.5"
+        - PYTHON_VERSION: "3.6"
+
+matrix:
+    allow_failures:
+        - PYTHON_VERSION: "3.5"
+        - PYTHON_VERSION: "3.6"
+
+install:
+    - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+    - "pip install tox coveralls"
+
+build: false
+
+test_script:
+    - "tox"
+
+after_test:
+  - "coveralls"

--- a/linkcheck/bookmarks/safari.py
+++ b/linkcheck/bookmarks/safari.py
@@ -16,8 +16,9 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import os
-import sys
 import plistlib
+import sys
+from xml.parsers.expat import ExpatError
 try:
     import biplist
     has_biplist = True
@@ -44,7 +45,7 @@ def find_bookmark_file ():
             fname = os.path.join(dirname, u"Bookmarks.plist")
             if os.path.isfile(fname):
                 return fname
-    except Exception:
+    except ExpatError:
         pass
     return u""
 
@@ -71,7 +72,7 @@ def get_plist_data_from_file (filename):
     # fall back to normal plistlist
     try:
         return plistlib.readPlist(filename)
-    except Exception:
+    except ExpatError:
         # not parseable (eg. not well-formed, or binary)
         return {}
 
@@ -84,7 +85,7 @@ def get_plist_data_from_string (data):
     # fall back to normal plistlist
     try:
         return plistlib.readPlistFromString(data)
-    except Exception:
+    except ExpatError:
         # not parseable (eg. not well-formed, or binary)
         return {}
 

--- a/tests/checker/data/http_file_windows.html
+++ b/tests/checker/data/http_file_windows.html
@@ -1,0 +1,1 @@
+<a href="file:///example/file">local file</a>

--- a/tests/checker/data/http_file_windows.html.result
+++ b/tests/checker/data/http_file_windows.html.result
@@ -1,0 +1,11 @@
+url http://localhost:%(port)d/%(datadir)s/http_file_windows.html
+cache key http://localhost:%(port)d/%(datadir)s/http_file_windows.html
+real url http://localhost:%(port)d/%(datadir)s/http_file_windows.html
+valid
+
+url file:////example/file
+cache key file:////example/file
+real url file:////example/file
+name local file
+error
+

--- a/tests/checker/test_http.py
+++ b/tests/checker/test_http.py
@@ -18,9 +18,10 @@
 Test http checking.
 """
 
-import pytest
+import os
 
-from .httpserver import HttpServerTest, CookieRedirectHttpRequestHandler
+from .httpserver import CookieRedirectHttpRequestHandler, HttpServerTest
+
 
 class TestHttp (HttpServerTest):
     """Test http:// link checking."""
@@ -36,7 +37,10 @@ class TestHttp (HttpServerTest):
         self.file_test("http_quotes.html", confargs=confargs)
         self.file_test("http_slash.html", confargs=confargs)
         self.file_test("http.xhtml", confargs=confargs)
-        self.file_test("http_file.html", confargs=confargs)
+        if os.name == "nt":
+            self.file_test("http_file_windows.html", confargs=confargs)
+        else:
+            self.file_test("http_file.html", confargs=confargs)
 
     def test_status(self):
         for status in sorted(self.handler.responses.keys()):

--- a/tests/test_urlbuild.py
+++ b/tests/test_urlbuild.py
@@ -18,10 +18,12 @@
 Test url build method from url data objects.
 """
 
+import os
 import unittest
+
+import linkcheck.checker.urlbase
 import linkcheck.configuration
 import linkcheck.director
-import linkcheck.checker.urlbase
 from linkcheck.checker import get_url_from
 
 
@@ -54,7 +56,7 @@ class TestUrlBuild (unittest.TestCase):
         res = linkcheck.checker.urlbase.urljoin(parent_url, base_url)
         self.assertEqual(res, 'http://localhost:8001/;param=value')
 
-    def test_urljoin_file (self):
+    def test_urljoin_file_posix (self):
         parent_url = "file:///a/b.html"
         base_url = "?c=d"
         recursion_level = 0
@@ -62,7 +64,12 @@ class TestUrlBuild (unittest.TestCase):
         o = get_url_from(base_url, recursion_level,
                aggregate, parent_url=parent_url)
         o.build_url()
-        self.assertEqual(o.url, parent_url)
+        if os.name == "nt":
+            # On Windows the UNC name should have 4 slashes
+            expected_url = "file:////a/b.html"
+        else:
+            expected_url = "file:///a/b.html"
+        self.assertEqual(o.url, expected_url)
 
     def test_http_build2 (self):
         parent_url = u'http://example.org/test?a=b&c=d'


### PR DESCRIPTION
I tried to add Windows testing. Unfortunately, `Travis-CI` doesn't support that. So I added configuration for `Appveyor`. Here are some results:
https://ci.appveyor.com/project/PetrDlouhy/linkchecker-1/history

There are some tests failing, so we will need to fix that before further development of Linkchecker to ensure it doesn't break anything on Windows.