### PR TITLE
introduce demotion rules

### DIFF
--- a/CONTRIBUTING.mdwn
+++ b/CONTRIBUTING.mdwn
@@ -135,3 +135,8 @@ requests.
 Maintainers can be promoted to administrators when they have given significant
 contributions for a sustained timeframe, by consensus of the current
 administrators. This process should be open and decided as any other issue.
+
+Maintainers can be demoted by administrators and administrators can be
+demoted by the other administrators' consensus. Unresponsive maintainers
+or administrators can be removed after a month unless they specifically
+announced a leave.


### PR DESCRIPTION
While reviewing our contribution guidelines in #139, we found we had no formal way of removing disappeared or idle maintainers, at least not explicitly, in the Membership section. This was a problem to get changes done on the contributing document which requires consensus from the maintainers.

This change introduces a way to make changes to the document by using it as a "vote of confidence", in a way: if a change is proposed and an administrator does not respond within a given 1-month delay, the administrator can be demoted down to a regular maintainer and the document approved.

Closes: #139