### PR TITLE
Update README to include easy installation instructions for pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,11 +28,11 @@ Features
 Installation
 -------------
 
-See doc/install.txt in the source code archive.
+See doc/install.txt in the source code archive for general information. Except the given information there, please take note of the following:
 
 Python 2.7.2 or later is needed. It doesn't work with Python 3 yet, see `#40 <https://github.com/linkcheck/linkchecker/pull/40>`_ for details.
 
-``pip install linkchecker`` should NOT be used for now, as it will install the old version of linkchecker. See `#4 <https://github.com/linkcheck/linkchecker/pull/4>`_.
+``pip install linkchecker`` should NOT be used for now, as it will install the old version of linkchecker. See `#4 <https://github.com/linkcheck/linkchecker/pull/4>`_. However, until this is resolved you can use `pip install git+https://github.com/linkchecker/linkchecker.git` to install the current git master version.
 
 Windows builds are seriously lagging behind the Linux releases, see `#53 <https://github.com/linkchecker/linkchecker/issues/53>`_ for details. For now, the only two options are to install from source or use `Docker for Windows <https://www.docker.com/docker-windows>`_.
 


### PR DESCRIPTION
See https://github.com/linkchecker/linkchecker/issues/4#issuecomment-356449159 

I had trouble installing but with `pip install git+https://github.com/linkchecker/linkchecker.git` it is quite easy and at the moment the easiest way imho.