### PR TITLE
Fix test requirements for Mac OS

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,8 @@
 # for testing:
+miniboa
 pytest
 pytest-xdist
 pyftpdlib
+parameterized
 # for building on osx:
 py2app

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,8 @@
 # for testing:
 miniboa
+parameterized
+pyftpdlib
 pytest
 pytest-xdist
-pyftpdlib
-parameterized
 # for building on osx:
 py2app


### PR DESCRIPTION
I was trying to run the unit tests following the guide in `development.mdwn` but ran into some issues. 

Most noticeably it seems that the tests use modules not specified as dependencies. This PR fixes that

I am also seeing: 
```
[gw2] darwin -- Python 2.7.15 /Users/cm/.pyenv/versions/2.7.15/bin/python2.7

self = <tests.checker.test_file.TestFile testMethod=test_unicode_filename>

    def test_unicode_filename (self):
        # a unicode filename
>       self.file_test(u"Мошкова.bin")

tests/checker/test_file.py:99: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/checker/__init__.py:226: in file_test
    self.fail_unicode(msg)
tests/checker/__init__.py:232: in fail_unicode
    self.fail(msg)
E   AssertionError: tests/checker/data/???????.bin
E   --- 
E   
E   +++ 
E   
E   @@ -2,4 +2,4 @@
E   
E    cache key file:///Users/cm/Realm/linkchecker/tests/checker/data/%D0%9C%D0%BE%D1%88%D0%BA%D0%BE%D0%B2%D0%B0.bin
E    real url file:///Users/cm/Realm/linkchecker/tests/checker/data/%D0%9C%D0%BE%D1%88%D0%BA%D0%BE%D0%B2%D0%B0.bin
E    name tests/checker/data/???????.bin
E   -valid
E   +error
```

Which looks like an encoding error somewhere, but it isn't clear to me why it is happening. For now, I just assume it is an environment setup error on my local machine somewhere and disabled `test_unicode_filename` in `test_file.py`. This makes it possible to run the test suite to completion