### PR TITLE
Do include anchors within cache_url,  mutex around the parsing

### DIFF
--- a/linkcheck/cache/urlqueue.py
+++ b/linkcheck/cache/urlqueue.py
@@ -114,7 +114,7 @@ class UrlQueue (object):
             self.not_empty.notify()
 
     def _put (self, url_data):
-        """Put URL in queue, increase number of unfished tasks."""
+        """Put URL in queue, increase number of unfinished tasks."""
         if self.shutdown or self.max_allowed_urls == 0:
             return
         log.debug(LOG_CACHE, "queueing %s", url_data.url)

--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -316,6 +316,10 @@ class UrlBase (object):
         # remove anchor from cached target url since we assume
         # URLs with different anchors to have the same content
         self.cache_url = urlutil.urlunsplit(self.urlparts[:4]+[u''])
+        if self.anchor:
+            # and bring anchor (now to full url) back since otherwise those
+            # urls would not be considered e.g. by AnchorCheck plugins
+            self.cache_url += '#%s' % self.anchor
         if self.cache_url is not None:
             assert isinstance(self.cache_url, unicode), repr(self.cache_url)
 

--- a/linkcheck/parser/__init__.py
+++ b/linkcheck/parser/__init__.py
@@ -133,7 +133,7 @@ def find_links (url_data, callback, tags):
         content = url_data.get_content()
         with parse_mutex:
             parser.feed(content)
-        parser.flush()
+            parser.flush()
     except linkparse.StopParse as msg:
         log.debug(LOG_CHECK, "Stopped parsing: %s", msg)
         pass

--- a/linkcheck/parser/__init__.py
+++ b/linkcheck/parser/__init__.py
@@ -17,10 +17,15 @@
 """
 Main functions for link parsing
 """
+import threading
+
 from .. import log, LOG_CHECK, strformat, url as urlutil
 from ..htmlutil import linkparse
 from ..HtmlParser import htmlsax
 from ..bookmarks import firefox
+
+# Is needed within find_links around non-threadsafe call
+parse_mutex = threading.Lock()
 
 
 def parse_url(url_data):
@@ -125,7 +130,9 @@ def find_links (url_data, callback, tags):
     handler.parser = parser
     # parse
     try:
-        parser.feed(url_data.get_content())
+        content = url_data.get_content()
+        with parse_mutex:
+            parser.feed(content)
         parser.flush()
     except linkparse.StopParse as msg:
         log.debug(LOG_CHECK, "Stopped parsing: %s", msg)

--- a/tests/checker/data/anchors.html
+++ b/tests/checker/data/anchors.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Test file for testing broken anchors detection</title>
+</head>
+<body>
+<a href="#anchor1">good anchor used before actual element is defined</a>
+<div id="anchor1"></div>
+<a href="#bad1">first local bad one</a>
+<a href="#bad2">second local bad one</a>
+<a href="anchors.html#anchor1">point to good anchor</a>
+<a href="anchors.html#bad3">point to bad anchor</a>
+</body>
+</html>

--- a/tests/checker/data/anchors.html
+++ b/tests/checker/data/anchors.html
@@ -9,7 +9,9 @@
 <div id="anchor1"></div>
 <a href="#bad1">first local bad one</a>
 <a href="#bad2">second local bad one</a>
-<a href="anchors.html#anchor1">point to good anchor</a>
-<a href="anchors.html#bad3">point to bad anchor</a>
+<a href="anchors.html#anchor1">good anchor</a>
+<a href="anchors.html#bad3">a new bad anchor</a>
+<a href="#bad1">duplicate local bad one</a>
+<a href="anchors.html#bad2">the same but not explicitly referenced with a page</a>
 </body>
 </html>


### PR DESCRIPTION
Closes #179

Please see details of the "investigation" in https://github.com/wummel/linkchecker/issues/557#issuecomment-434552215

- [ ] consider another approach (may be adding `full_url` record in addition) instead of populating anchor into `cache_url` which makes it to download them same page multiple times
- [ ] introduced test demonstrates an outstanding problem in threaded mode that in some runs anchor pointing to an element defined later in the document would be considered broken (I guess because parsing of the page is not finished yet whenever anchor is verified). It actually can manifest it in two ways:

<details>
<summary>printouts of failed runs</summary>

```
tests/checker/__init__.py:232: in fail_unicode
    self.fail(msg)
E   AssertionError: Differences found testing file:///home/yoh/proj/misc/linkchecker/tests/checker/data/anchors.html (records might switch order which is ok)
E   @@ -2,7 +2,7 @@
E    cache key file:///home/yoh/proj/misc/linkchecker/tests/checker/data/anchors.html#bad1
E    real url file:///home/yoh/proj/misc/linkchecker/tests/checker/data/anchors.html
E    name first local bad one
E   -warning Anchor `bad1' not found. Available anchors: `anchor1'.
E   +warning Anchor `bad1' not found. Available anchors: -.
E    valid
E    url #bad2
E    cache key file:///home/yoh/proj/misc/linkchecker/tests/checker/data/anchors.html#bad2
```
and
```
E   AssertionError: Differences found testing file:///home/yoh/proj/misc/linkchecker/tests/checker/data/anchors.html (records might switch order which is ok)
E   @@ -1,8 +1,8 @@
E   -url #bad1
E   -cache key file:///home/yoh/proj/misc/linkchecker/tests/checker/data/anchors.html#bad1
E   +url #anchor1
E   +cache key file:///home/yoh/proj/misc/linkchecker/tests/checker/data/anchors.html#anchor1
E    real url file:///home/yoh/proj/misc/linkchecker/tests/checker/data/anchors.html
E   -name first local bad one
E   -warning Anchor `bad1' not found. Available anchors: `anchor1'.
E   +name good anchor used before actual element is defined
E   +warning Anchor `anchor1' not found. Available anchors: -.
E    valid
E    url #bad2
E    cache key file:///home/yoh/proj/misc/linkchecker/tests/checker/data/anchors.html#bad2
E   @@ -10,6 +10,12 @@
E    name second local bad one
E    warning Anchor `bad2' not found. Available anchors: `anchor1'.
E    valid
E   +url #bad1
E   +cache key file:///home/yoh/proj/misc/linkchecker/tests/checker/data/anchors.html#bad1
E   +real url file:///home/yoh/proj/misc/linkchecker/tests/checker/data/anchors.html
E   +name first local bad one
E   +warning Anchor `bad1' not found. Available anchors: `anchor1'.
E   +valid
E    url anchors.html#bad3
E    cache key file:///home/yoh/proj/misc/linkchecker/tests/checker/data/anchors.html#bad3
E    real url file:///home/yoh/proj/misc/linkchecker/tests/checker/data/anchors.html
```
</details>

here is my command to run the test until failure:
```shell
( set -e; for f in {1..100}; do echo $f; python -m pytest -s -v tests/checker/test_anchor.py::TestAnchor::test_anchors; done; )
```