### PR TITLE
Require a recent Requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # required:
-requests<2.15,>=2.4
+requests >= 2.20.0
 pyxdg
 dnspython
 # optional:

--- a/setup.py
+++ b/setup.py
@@ -501,7 +501,7 @@ args = dict(
     },
     # Requirements, usable with setuptools or the new Python packaging module.
     install_requires = [
-        'requests<2.15,>=2.4',
+        'requests >= 2.20.0',
         'dnspython',
         'pyxdg',
     ],


### PR DESCRIPTION
Requests versions <= 2.19.1 are vulnerable to CVE-2018-18074:

> The Requests package through 2.19.1 before 2018-09-14 for Python sends
> an HTTP Authorization header to an http URI upon receiving a
> same-hostname https-to-http redirect, which makes it easier for remote
> attackers to discover credentials by sniffing the network.

Thank you, GitHub security alerts, for bringing this to my attention.

I do not recall why we were pinning requests to `< 2.15` and I hope Travis CI will remind me.