### PR TITLE
lower requirements to allow install on older systems

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # required:
-requests >= 2.20.0
+requests >= 2.4
 pyxdg
 dnspython
 # optional:

--- a/setup.py
+++ b/setup.py
@@ -501,7 +501,7 @@ args = dict(
     },
     # Requirements, usable with setuptools or the new Python packaging module.
     install_requires = [
-        'requests >= 2.20.0',
+        'requests >= 2.4',
         'dnspython',
         'pyxdg',
     ],


### PR DESCRIPTION
PR #196 bumped this to 2.20 to fix a security warning about requests
in our repository, but I believe that warning can be fixed by removing
only the upper bound. This should make backporting linkchecker to
older systems easier, where requests presumably has the 2.20 fix
backported.