### PR TITLE
{python3_05a} Use Python 3 compatible octal masks

### DIFF
--- a/linkcheck/configuration/__init__.py
+++ b/linkcheck/configuration/__init__.py
@@ -403,7 +403,7 @@ def make_userdir(child):
             # Windows forbids filenames with leading dot unless
             # a trailing dot is added.
             userdir += "."
-        os.makedirs(userdir, 0700)
+        os.makedirs(userdir, 0o700)
 
 
 def get_user_config():

--- a/linkcheck/logger/blacklist.py
+++ b/linkcheck/logger/blacklist.py
@@ -90,7 +90,7 @@ class BlacklistLogger (_Logger):
         """
         Write the blacklist.
         """
-        oldmask = os.umask(0077)
+        oldmask = os.umask(0o077)
         for key, value in self.blacklist.items():
             self.write(u"%d %s%s" % (value, repr(key), os.linesep))
         self.close_fileoutput()


### PR DESCRIPTION
Split from #215.
