### PR TITLE
[WIP] Avoid segfaults while testing on Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,7 @@ matrix:
    allow_failures:
       - python: "3.5"
       - python: "3.6"
+env:
+  global:
+    # workaround Python 3.6 incompatibility #238
+    - PYTHONMALLOC=malloc

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ sign:
 	done
 
 test:	localbuild
-	env LANG=en_US.utf-8 $(PYTHON) -m pytest $(PYTESTOPTS) $(TESTOPTS) $(TESTS)
+	env LANG=en_US.utf-8 PYTHONMALLOC=malloc $(PYTHON) -m pytest $(PYTESTOPTS) $(TESTOPTS) $(TESTS)
 
 pyflakes:
 	pyflakes $(PY_FILES_DIRS) 2>&1 | \

--- a/tox.ini
+++ b/tox.ini
@@ -14,3 +14,4 @@ commands =
     py.test {posargs:--tb=short --cov=linkcheck tests}
 setenv =
     LC_ALL=en_US.utf-8
+passenv = PYTHONMALLOC


### PR DESCRIPTION
Default memory allocator changed in Python 3.6 to pymalloc, where available, meaning:

> The GIL must now be held when allocator functions of PYMEM_DOMAIN_OBJ (ex: PyObject_Malloc()) and PYMEM_DOMAIN_MEM (ex: PyMem_Malloc()) domains are called.

https://docs.python.org/3.6/whatsnew/3.6.html#build-and-c-api-changes

The allocator can be set from the C API, but it's a bit complex for me. Setting PYTHONMALLOC is a workaround to get the tests running.

Obviously this doesn't just affect testing though. Another reason to replace the parser?
