### PR TITLE
Replace deprecated log.warn

### DIFF
--- a/linkcheck/log.py
+++ b/linkcheck/log.py
@@ -102,7 +102,7 @@ def warn (logname, msg, *args, **kwargs):
     """
     log = logging.getLogger(logname)
     if log.isEnabledFor(logging.WARN):
-        _log(log.warn, msg, args, **kwargs)
+        _log(log.warning, msg, args, **kwargs)
 
 
 def error (logname, msg, *args, **kwargs):


### PR DESCRIPTION
warning() has been the documented method since logging was introduced in
Python 2.3.

--- 

Resolves deprecation warnings.