### PR TITLE
Fix mistakes in changes to test_dummy.py and test_updater.py in 8f4acc31

### DIFF
--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -21,7 +21,7 @@ Test dummy object.
 import sys
 import unittest
 
-from builtins import bytes, str
+from builtins import str
 
 import linkcheck.dummy
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -39,4 +39,4 @@ class TestUpdater (unittest.TestCase):
                 self.assertTrue(isinstance(version, str), repr(version))
                 self.assertTrue(url is None or isinstance(url, str), repr(url))
         else:
-            self.assertTrue(isinstance(value, unicode), repr(value))
+            self.assertTrue(isinstance(value, str), repr(value))


### PR DESCRIPTION
In test_dummy.py bytes import was left over from previous version of the change
In test_updater.py an instance of unicode() was left unchanged.
