### PR TITLE
Import str as str_text from builtins when supporting transition

### DIFF
--- a/tests/configuration/test_config.py
+++ b/tests/configuration/test_config.py
@@ -21,15 +21,15 @@ Test config parsing.
 import unittest
 import os
 import linkcheck.configuration
-from builtins import str
+from builtins import str as str_text
 
 
 def get_file (filename=None):
     """Get file name located within 'data' directory."""
     directory = os.path.join("tests", "configuration", "data")
     if filename:
-        return str(os.path.join(directory, filename))
-    return str(directory)
+        return str_text(os.path.join(directory, filename))
+    return str_text(directory)
 
 
 class TestConfig (unittest.TestCase):


### PR DESCRIPTION
Expected to be removed when the project moves to Python 3 only.