### PR TITLE
Make TestRobotsTxt Python 3.7 compatible

### DIFF
--- a/tests/test_robotstxt.py
+++ b/tests/test_robotstxt.py
@@ -18,6 +18,7 @@
 Test robots.txt parsing.
 """
 
+import sys
 import unittest
 import linkcheck.robotparser2
 
@@ -224,7 +225,8 @@ class TestRobotsTxt (unittest.TestCase):
             "Disallow: /tmp",
             "Disallow: /a%3Cd.html",
             "Disallow: /a/b.html",
-            "Disallow: /%7Ejoe/index.html",
+            "Disallow: /%7Ejoe/index.html" if sys.version_info < (3, 7) \
+            else "Disallow: /~joe/index.html",
         ]
         self.rp.parse(lines)
         self.assertEqual(str(self.rp), "\n".join(lines2))
@@ -249,7 +251,8 @@ class TestRobotsTxt (unittest.TestCase):
             "Disallow: /tmp/",
             "Disallow: /a%3Cd.html",
             "Disallow: /a/b.html",
-            "Disallow: /%7Ejoe/index.html",
+            "Disallow: /%7Ejoe/index.html" if sys.version_info < (3, 7) \
+            else "Disallow: /~joe/index.html",
         ]
         self.rp.parse(lines)
         self.assertEqual(str(self.rp), "\n".join(lines2))


### PR DESCRIPTION
urllib.parse.quote() moved from RFC 2396 to RFC 3986 for quoting URL
strings. “~” is now included in the set of reserved characters.