### PR TITLE
Get FtpServerTest working by updating to current pyftpdlib API

### DIFF
--- a/linkcheck/checker/ftpurl.py
+++ b/linkcheck/checker/ftpurl.py
@@ -25,6 +25,8 @@ except ImportError:
     # Python 3
     from io import StringIO
 
+from builtins import bytes
+
 from .. import log, LOG_CHECK, LinkCheckerError, mimeutil
 from . import proxysupport, httpurl, internpaturl, get_index_html
 from .const import WARN_FTP_MISSING_SLASH
@@ -116,7 +118,9 @@ class FtpUrl (internpaturl.InternPatternUrl, proxysupport.ProxySupport):
         Change to URL parent directory. Return filename of last path
         component.
         """
-        path = self.urlparts[2].encode(self.filename_encoding, 'replace')
+        path = self.urlparts[2]
+        if isinstance(path, bytes):
+            path = path.decode(self.filename_encoding, 'replace')
         dirname = path.strip('/')
         dirs = dirname.split('/')
         filename = dirs.pop()


### PR DESCRIPTION
Two commits to two separate files:

* tests/checker/ftpserver.py - has been skipped for some time because pyftpdlib had changed
* linkcheck/checker/ftpurl.py - for Python 3 compatibility

Wouldn't be much to see from Travis because Python 2.7 passes the test without the second commit (and Python 3 no where near passing with this branch). For reference Python 3 failure on python3 branch without the second commit:
```
_______________________________ TestFtp.test_ftp _______________________________
tests/__init__.py:93: in newfunc
    return func(*args, **kwargs)
tests/checker/test_ftp.py:47: in test_ftp
    self.direct(url, resultlines)
tests/checker/__init__.py:267: in direct
    self.fail_unicode(str_text(os.linesep).join(l))
tests/checker/__init__.py:244: in fail_unicode
    self.fail(msg)
E   AssertionError: Differences found testing ftp://anonymous:Ftp@localhost:35860/
E   @@ -1,4 +0,0 @@
E   -url ftp://anonymous:Ftp@localhost:35860/
E   -cache key ftp://anonymous:Ftp@localhost:35860/
E   -real url ftp://anonymous:Ftp@localhost:35860/
E   -valid
----------------------------- Captured stderr call -----------------------------
```