### PR TITLE
{python3_18a} Python3: fix strformat ascii_safe() and unicode_safe()

### DIFF
--- a/linkcheck/strformat.py
+++ b/linkcheck/strformat.py
@@ -56,10 +56,10 @@ def unicode_safe (s, encoding=i18n.default_encoding, errors='replace'):
     @rtype: unicode
     """
     assert s is not None, "argument to unicode_safe was None"
-    if isinstance(s, unicode):
+    if isinstance(s, str_text):
         # s is already unicode, nothing to do
         return s
-    return unicode(str(s), encoding, errors)
+    return str_text(bytes(s), encoding, errors)
 
 
 def ascii_safe (s):
@@ -71,7 +71,7 @@ def ascii_safe (s):
     @return: encoded ASCII version of s, or None if s was None
     @rtype: string
     """
-    if isinstance(s, unicode):
+    if isinstance(s, str_text):
         s = s.encode('ascii', 'ignore')
     return s
 

--- a/linkcheck/strformat.py
+++ b/linkcheck/strformat.py
@@ -59,7 +59,12 @@ def unicode_safe (s, encoding=i18n.default_encoding, errors='replace'):
     if isinstance(s, str_text):
         # s is already unicode, nothing to do
         return s
-    return str_text(str(s), encoding, errors)
+
+    try:
+        ret_str = unicode(str(s), encoding, errors)
+    except NameError:
+        ret_str = s
+    return ret_str
 
 
 def ascii_safe (s):

--- a/linkcheck/strformat.py
+++ b/linkcheck/strformat.py
@@ -59,7 +59,7 @@ def unicode_safe (s, encoding=i18n.default_encoding, errors='replace'):
     if isinstance(s, str_text):
         # s is already unicode, nothing to do
         return s
-    return str_text(bytes(s), encoding, errors)
+    return str_text(str(s), encoding, errors)
 
 
 def ascii_safe (s):

--- a/linkcheck/strformat.py
+++ b/linkcheck/strformat.py
@@ -64,7 +64,8 @@ def unicode_safe (s, encoding=i18n.default_encoding, errors='replace'):
         return unicode(str(s), encoding, errors)
     except NameError:  # Python3
         if isinstance(s, bytes):
-            return s.decode("utf-8", errors)
+            return s.decode(encoding, errors)
+        return str(s)
 
 
 def ascii_safe (s):

--- a/linkcheck/strformat.py
+++ b/linkcheck/strformat.py
@@ -61,10 +61,10 @@ def unicode_safe (s, encoding=i18n.default_encoding, errors='replace'):
         return s
 
     try:
-        ret_str = unicode(str(s), encoding, errors)
-    except NameError:
-        ret_str = s
-    return ret_str
+        return unicode(str(s), encoding, errors)
+    except NameError:  # Python3
+        if isinstance(s, bytes):
+            return s.decode("utf-8", errors)
 
 
 def ascii_safe (s):


### PR DESCRIPTION
branched from python3_18 #228.
