### PR TITLE
Make test_all_parts TestLogger import Python 3 compatible

### DIFF
--- a/tests/checker/__init__.py
+++ b/tests/checker/__init__.py
@@ -36,6 +36,9 @@ class TestLogger (linkcheck.logger._Logger):
     """
     Output logger for automatic regression tests.
     """
+    
+    # don't attempt to collect this class because it has an __init__()
+    __test__ = False
 
     LoggerName = 'test'
 

--- a/tests/checker/test_all_parts.py
+++ b/tests/checker/test_all_parts.py
@@ -18,10 +18,9 @@
 Test http checking.
 """
 from . import LinkCheckTest
-import __init__ as init
+from . import TestLogger
 
-
-class AllPartsLogger(init.TestLogger):
+class AllPartsLogger(TestLogger):
     logparts = [
         'cachekey',
         'realurl',


### PR DESCRIPTION
tests/checker/test_all_parts.py:21: in <module>
    import __init__ as init
E   ModuleNotFoundError: No module named '__init__'

testWarning: cannot collect test class 'TestLogger' because it has a
__init__ constructor
