### PR TITLE
Fix a hanging test on Python 3

### DIFF
--- a/tests/checker/telnetserver.py
+++ b/tests/checker/telnetserver.py
@@ -49,7 +49,7 @@ class TelnetServerTest (LinkCheckTest):
 
     def setUp (self):
         """Start a new Telnet server in a new thread."""
-        deadline = time.time() + 2 * TIMEOUT
+        deadline = time.time() + 10 * TIMEOUT
         self.port = start_server(self.host, 0, deadline=deadline)
         self.assertFalse(self.port is None)
 


### PR DESCRIPTION
I'm not entirely sure why the test is hanging, but this seems clear
enough:

- the test setup spawns a (non-daemon) background thread that runs
  forever, or until it is told to quit by receiving a TCP packet on a
  certain port
- the test teardown tries to tell the background thread to quit (which
  doesn't work) and waits for that to happen
- as a result the entire test run hangs forever

This commit adds a timeout as an extra safety net so that the test run
will complete even if the clean shutdown procedure fails for some
reason.