### PR TITLE
Make test_telnet.py fast

### DIFF
--- a/tests/checker/telnetserver.py
+++ b/tests/checker/telnetserver.py
@@ -65,7 +65,7 @@ def start_server (host, port, stop_event):
     clients = []
     def on_connect(client):
         clients.append(client)
-        client.send("Telnet test server\n")
+        client.send("Telnet test server\nlogin: ")
     server = miniboa.TelnetServer(port=port, address=host, on_connect=on_connect)
     port = server.server_socket.getsockname()[1]
     t = threading.Thread(None, serve_forever, args=(server, clients, stop_event))
@@ -100,3 +100,5 @@ def handle_cmd(client):
     msg = client.get_command().lower()
     if msg == 'exit':
         client.active = False
+    else:
+        client.send("Password: ")


### PR DESCRIPTION
Linkchecker's telnet://username:password@host:port URL verification logic is

- connect to host:port
- wait for 'login: ' to appear (with a 10 second timeout), send username
- wait for 'Password: ' to appear (with a 10 second timeout), send password

The test spawns a fake telnet server on localhost that never presented
the login/password prompts, forcing the 10 second timeout three times.

This commit makes the fake telnet server emit the expected prompts,
making the test pass in .2 seconds.