### PR TITLE
Replace deprecated cgi.parse_qs

### DIFF
--- a/linkcheck/lc_cgi.py
+++ b/linkcheck/lc_cgi.py
@@ -54,7 +54,7 @@ def application(environ, start_response):
         request_body = environ['wsgi.input'].read(request_body_size)
     else:
         request_body = environ['wsgi.input'].read()
-    form = cgi.parse_qs(request_body)
+    form = urlparse.parse_qs(request_body)
 
     status = '200 OK'
     start_response(status, get_response_headers())


### PR DESCRIPTION
2.7 docs say:

This function is deprecated in this module. Use urlparse.parse_qs() instead. It is maintained here only for backward compatibility.
