### PR TITLE
Fix failing test

### DIFF
--- a/tests/checker/test_http_misc.py
+++ b/tests/checker/test_http_misc.py
@@ -60,8 +60,8 @@ class TestHttpMisc (HttpServerTest):
         resultlines = [
             u"url %s" % url,
             u"cache key %s" % rurl,
-            u"real url %s" % rurl,
-            u"info Access denied by robots.txt, checked only syntax.",
+            u"real url https://%s/" % host,
+            u"info Redirected to `https://%s/'." % host,
             u"warning URL %s has obfuscated IP address %s" % (url, ip),
             u"valid",
         ]


### PR DESCRIPTION
http://www.heise.de/ now does a redirect to HTTPS instead of denying our crawl via robots.txt.

Fixes #269.