### PR TITLE
Add Python 3.7 to the Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
 # command to install dependencies
 install:
   - pip install tox-travis coveralls
@@ -18,3 +19,4 @@ matrix:
    allow_failures:
       - python: "3.5"
       - python: "3.6"
+      - python: "3.7"


### PR DESCRIPTION
(The tests don't pass yet, see #205.)