### PR TITLE
[WIP] Prepare test_parse.py for bs4 when using Python 2

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -20,10 +20,7 @@ Test html parsing.
 
 import linkcheck.HtmlParser.htmlsax
 import linkcheck.HtmlParser.htmllib
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 import unittest
 
 from parameterized import parameterized


### PR DESCRIPTION
When testing Beautiful Soup on Python 2 multiple test_parse.py tests are failing with UnicodeEncodeErrors e.g.:
```
self = <linkcheck.HtmlParser.htmllib.HtmlPrettyPrinter object at 0x7f2a1566d310>, tag = 'a', attrs = {u'a\xe4': u'b'}, end = '>'

    def _start_element (self, tag, attrs, end):
...
        self.fd.write(u"<%s" % tag.replace("/", ""))
        for key, val in attrs.items():
            if val is None:
                self.fd.write(u" %s" % key)
            else:
>               self.fd.write(u' %s="%s"' % (key, quote_attrval(val)))
E               UnicodeEncodeError: 'ascii' codec can't encode character u'\xe4' in position 2: ordinal not in range(128)

linkcheck/HtmlParser/htmllib.py:133: UnicodeEncodeError
```
---

This is what I was referring to in:
https://github.com/linkchecker/linkchecker/pull/278#discussion_r322589576

Maybe it is fixing the wrong thing - it is found by taking #249, removing the Python 3 only commits and testing with Python 2. There are still 4 other test failures.
