### PR TITLE
{python3_39_alt} Python3: fix TypeError in HttpUrl.read_content()

### DIFF
--- a/linkcheck/checker/httpurl.py
+++ b/linkcheck/checker/httpurl.py
@@ -26,11 +26,7 @@ import requests
 import warnings
 warnings.simplefilter('ignore', requests.packages.urllib3.exceptions.InsecureRequestWarning)
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    # Python 3
-    from io import StringIO
+from io import BytesIO
 
 from .. import (log, LOG_CHECK, strformat, mimeutil,
     url as urlutil, LinkCheckerError, httputil)
@@ -316,7 +312,7 @@ class HttpUrl (internpaturl.InternPatternUrl, proxysupport.ProxySupport):
         """Return data and data size for this URL.
         Can be overridden in subclasses."""
         maxbytes = self.aggregate.config["maxfilesizedownload"]
-        buf = StringIO()
+        buf = BytesIO()
         for data in self.url_connection.iter_content(chunk_size=self.ReadChunkBytes):
             if buf.tell() + len(data) > maxbytes:
                 raise LinkCheckerError(_("File size too large"))


### PR DESCRIPTION
From test_http_redirect:
```
  File "linkchecker/linkcheck/checker/httpurl.py", line 323, in read_content
    line: buf.write(data)
    locals:
      buf = <local> <_io.StringIO object at 0x7f8fe2f45e10>
      buf.write = <local> <built-in method write of _io.StringIO object at 0x7f8fe2f45e10>
      data = <local> b'<a href="newurl.html">Recursive Redirect</a>\n'
TypeError: string argument expected, got 'bytes'
```
---

This is my version of 1a4663b48
