### PR TITLE
Decode content when retrieved

### DIFF
--- a/linkcheck/bookmarks/opera.py
+++ b/linkcheck/bookmarks/opera.py
@@ -63,9 +63,9 @@ def parse_bookmark_data (data):
     for line in data.splitlines():
         lineno += 1
         line = line.strip()
-        if line.startswith(b"NAME="):
+        if line.startswith("NAME="):
             name = line[5:]
-        elif line.startswith(b"URL="):
+        elif line.startswith("URL="):
             url = line[4:]
             if url and name is not None:
                 yield (url, name, lineno)

--- a/linkcheck/director/aggregator.py
+++ b/linkcheck/director/aggregator.py
@@ -90,8 +90,7 @@ class Aggregate (object):
         response = session.get(url)
         cgiuser = self.config["loginuserfield"]
         cgipassword = self.config["loginpasswordfield"]
-        form = formsearch.search_form(response.content, cgiuser, cgipassword,
-              encoding=response.encoding)
+        form = formsearch.search_form(response.text, cgiuser, cgipassword)
         form.data[cgiuser] = user
         form.data[cgipassword] = password
         for key, value in self.config["loginextrafields"].items():

--- a/linkcheck/parser/__init__.py
+++ b/linkcheck/parser/__init__.py
@@ -72,7 +72,7 @@ def parse_chromium (url_data):
 def parse_safari (url_data):
     """Parse a Safari bookmark file."""
     from ..bookmarks.safari import parse_bookmark_data
-    for url, name in parse_bookmark_data(url_data.get_content()):
+    for url, name in parse_bookmark_data(url_data.get_raw_content()):
         url_data.add_url(url, name=name)
 
 

--- a/linkcheck/parser/__init__.py
+++ b/linkcheck/parser/__init__.py
@@ -83,7 +83,7 @@ def parse_text (url_data):
     for line in url_data.get_content().splitlines():
         lineno += 1
         line = line.strip()
-        if not line or line.startswith(b'#'):
+        if not line or line.startswith('#'):
             continue
         url_data.add_url(line, line=lineno)
 

--- a/linkcheck/plugins/markdowncheck.py
+++ b/linkcheck/plugins/markdowncheck.py
@@ -31,6 +31,7 @@ import re
 from . import _ContentPlugin
 from .. import log, LOG_PLUGIN
 
+from builtins import str as str_text
 
 class MarkdownCheck(_ContentPlugin):
     """Markdown parsing plugin."""
@@ -108,7 +109,7 @@ class MarkdownCheck(_ContentPlugin):
         """
         line = content.count('\n', 0, url_pos) + 1
         column = url_pos - content.rfind('\n', 0, url_pos)
-        url_data.add_url(url_text.translate(None, '\n '), line=line, column=column)
+        url_data.add_url(url_text.translate(str_text.maketrans("", "", '\n ')), line=line, column=column)
 
     def _check_by_re(self, url_data, content):
         """ Finds urls by re.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # required:
+bs4
 requests >= 2.4
 pyxdg
 dnspython

--- a/setup.py
+++ b/setup.py
@@ -503,6 +503,7 @@ args = dict(
     install_requires = [
         'requests >= 2.4',
         'dnspython',
+        'bs4',
         'pyxdg',
         'future',
     ],


### PR DESCRIPTION
Not for merging yet, it needs reviewing and is based on the other two big branches. As such only the "Commits on Sep 20, 2019" should be considered.

The key change is to decode early in HttpUrl or UrlBase. HttpUrl uses requests to do the decoding, UrlBase tries UTF-8 and if that fails uses Beautiful Soup to detect the encoding.

This would replace #295, #296, #304 and simplify #298.
