### PR TITLE
Remove unnecessary unicode() from StatusLogger.writeln()

### DIFF
--- a/linkcheck/director/console.py
+++ b/linkcheck/director/console.py
@@ -63,7 +63,7 @@ class StatusLogger (object):
 
     def writeln (self, msg):
         """Write status message and line break to file descriptor."""
-        self.fd.write(u"%s%s" % (msg, unicode(os.linesep)))
+        self.fd.write(u"%s%s" % (msg, os.linesep))
 
     def flush (self):
         """Flush file descriptor."""


### PR DESCRIPTION
Can't see that this was needed on Python 2. Obviously causes an exception on Python 3.