### PR TITLE
Add new tests for URL quoting

### DIFF
--- a/tests/checker/data/file_url_quote.html
+++ b/tests/checker/data/file_url_quote.html
@@ -1,0 +1,6 @@
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<a href="http://localhost:8001/?quoted=ü">l1</a>
+<a href="http://localhost:8001/?quoted=%FC">The same address as l1 therefore not reported</a>
+<a href="http://localhost:8001/?quoted=%FF">l2</a>
+<a href="mailto:ölvin@users.sourceforge.net">l3</a>
+<a href="mailto:%E4lvin@users.sourceforge.net">l4</a>

--- a/tests/checker/data/file_url_quote.html.result
+++ b/tests/checker/data/file_url_quote.html.result
@@ -1,0 +1,29 @@
+url file://%(curdir)s/%(datadir)s/file_url_quote.html
+cache key file://%(curdir)s/%(datadir)s/file_url_quote.html
+real url file://%(curdir)s/%(datadir)s/file_url_quote.html
+name %(datadir)s/file_url_quote.html
+valid
+
+url http://localhost:8001/?quoted=ü
+cache key http://localhost:8001/?quoted=%%C3%%BC
+real url http://localhost:8001/?quoted=%%C3%%BC
+name l1
+error
+
+url http://localhost:8001/?quoted=%%FF
+cache key http://localhost:8001/?quoted=%%C3%%BF
+real url http://localhost:8001/?quoted=%%C3%%BF
+name l2
+error
+
+url mailto:ölvin@users.sourceforge.net
+cache key mailto:ölvin@users.sourceforge.net
+real url mailto:%%C3%%B6lvin@users.sourceforge.net
+name l3
+valid
+
+url mailto:%%E4lvin@users.sourceforge.net
+cache key mailto:älvin@users.sourceforge.net
+real url mailto:%%C3%%A4lvin@users.sourceforge.net
+name l4
+valid

--- a/tests/checker/data/http_url_quote.html
+++ b/tests/checker/data/http_url_quote.html
@@ -1,0 +1,6 @@
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<a href="http://localhost:8001/?quoted=ü">l1</a>
+<a href="http://localhost:8001/?quoted=%FC">The same address as l1 therefore not reported</a>
+<a href="http://localhost:8001/?quoted=%FF">l2</a>
+<a href="mailto:ölvin@users.sourceforge.net">l3</a>
+<a href="mailto:%E4lvin@users.sourceforge.net">l4</a>

--- a/tests/checker/data/http_url_quote.html.result
+++ b/tests/checker/data/http_url_quote.html.result
@@ -1,0 +1,28 @@
+url http://localhost:%(port)d/%(datadir)s/http_url_quote.html
+cache key http://localhost:%(port)d/%(datadir)s/http_url_quote.html
+real url http://localhost:%(port)d/%(datadir)s/http_url_quote.html
+valid
+
+url http://localhost:8001/?quoted=ü
+cache key http://localhost:8001/?quoted=%%C3%%BC
+real url http://localhost:8001/?quoted=%%C3%%BC
+name l1
+error
+
+url http://localhost:8001/?quoted=%%FF
+cache key http://localhost:8001/?quoted=%%C3%%BF
+real url http://localhost:8001/?quoted=%%C3%%BF
+name l2
+error
+
+url mailto:ölvin@users.sourceforge.net
+cache key mailto:ölvin@users.sourceforge.net
+real url mailto:%%C3%%B6lvin@users.sourceforge.net
+name l3
+valid
+
+url mailto:%%E4lvin@users.sourceforge.net
+cache key mailto:älvin@users.sourceforge.net
+real url mailto:%%C3%%A4lvin@users.sourceforge.net
+name l4
+valid

--- a/tests/checker/test_file.py
+++ b/tests/checker/test_file.py
@@ -51,6 +51,9 @@ class TestFile (LinkCheckTest):
     def test_html (self):
         self.file_test("file.html")
 
+    def test_html_url_quote (self):
+        self.file_test("file_url_quote.html")
+
     def test_wml (self):
         self.file_test("file.wml")
 

--- a/tests/checker/test_http.py
+++ b/tests/checker/test_http.py
@@ -39,6 +39,7 @@ class TestHttp (HttpServerTest):
         self.file_test("http_slash.html", confargs=confargs)
         self.file_test("http.xhtml", confargs=confargs)
         self.file_test("http_file.html", confargs=confargs)
+        self.file_test("http_url_quote.html", confargs=confargs)
 
     def test_status(self):
         for status in sorted(self.handler.responses.keys()):


### PR DESCRIPTION
Check that the encoding detected in UrlBase is then used correctly to
quote URLs.