### PR TITLE
Remove unused linkparse.TitleFinder

### DIFF
--- a/linkcheck/htmlutil/linkparse.py
+++ b/linkcheck/htmlutil/linkparse.py
@@ -24,7 +24,6 @@ from . import linkname
 from builtins import str as str_text
 
 MAX_NAMELEN = 256
-MAX_TITLELEN = 256
 
 unquote = strformat.unquote
 
@@ -100,26 +99,6 @@ def strip_c_comments (text):
 class StopParse(Exception):
     """Raised when parsing should stop."""
     pass
-
-
-class TitleFinder (object):
-    """Find title tags in HTML text."""
-
-    def __init__ (self):
-        """Initialize title."""
-        super(TitleFinder, self).__init__()
-        log.debug(LOG_CHECK, "HTML title parser")
-        self.title = None
-
-    def start_element (self, tag, attrs):
-        """Search for <title> tag."""
-        if tag == 'title':
-            data = self.parser.peek(MAX_TITLELEN)
-            data = data.decode(self.parser.encoding, "ignore")
-            self.title = linkname.title_name(data)
-            raise StopParse("found <title> tag")
-        elif tag == 'body':
-            raise StopParse("found <body> tag")
 
 
 class TagFinder (object):


### PR DESCRIPTION
Stopped being used with removal of UrlBase.set_title_from_content() in:

7b34be59 ("Introduce check plugins, use Python requests for http/s connections, and some code cleanups and improvements.", 2014-03-01)

---

This is dead code in current master. Needs to go as well because the new parser doesn't support peek().
