### PR TITLE
Don't add linkcheck_dns directory to sys.path

### DIFF
--- a/linkcheck/__init__.py
+++ b/linkcheck/__init__.py
@@ -37,11 +37,6 @@ if int(requests_version[0]) < 2 or \
     raise SystemExit("This program requires Python requests 2.4.0 or later instead of %s." % requests.__version__)
 
 import os
-# add the custom linkcheck_dns directory to sys.path
-_dnspath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'linkcheck_dns'))
-if _dnspath not in sys.path:
-    sys.path.insert(0, _dnspath)
-del _dnspath
 import re
 import signal
 import traceback


### PR DESCRIPTION
This code was added in:
efbbb656 ("Remove python-dns conflict by moving the dns module into a custom subdirectory.", 2012-12-07)

Installation of linkcheck_dns stopped with:
0a13fae3 ("remove third party packages and use them as dependency", 2018-01-06)
.
