### PR TITLE
Wait for threads to exit after stopping them

### DIFF
--- a/linkcheck/director/aggregator.py
+++ b/linkcheck/director/aggregator.py
@@ -199,6 +199,8 @@ class Aggregate (object):
             self.cancel()
         for t in self.threads:
             t.stop()
+        for t in self.threads:
+            t.join(timeout=1.0)
 
     @synchronized(_threads_lock)
     def is_finished (self):


### PR DESCRIPTION
This fixes a race condition where the main thread would check if any
internal errors happened and get back a 0 while a worker thread was
still busy printing the internal error message before incrementing the
counter.

Fixes #320.

My experiments show that this adds no perceptible delay to the script
runtime (on Linux).  More specifically, there already is an annoying
perceptible delay of about 1 second, but it's not caused by this change.

I thought about adding a regression test for this, but couldn't come up with a way to do it.