### PR TITLE
Fix MS Word parser, hopefully

### DIFF
--- a/linkcheck/plugins/parseword.py
+++ b/linkcheck/plugins/parseword.py
@@ -117,7 +117,7 @@ class WordParser(_ParserPlugin):
 
     def check(self, url_data):
         """Parse Word data."""
-        content = url_data.get_content()
+        content = url_data.get_raw_content()
         filename = get_temp_filename(content)
         # open word file and parse hyperlinks
         try:


### PR DESCRIPTION
MS Word files are binary data, and get_temp_filename() will write them
to disk using open(..., 'wb'), so we want to pass bytes in there, not
Unicode.

See #323.

If anyone has a Windows machine with Word installed and would like to test this code, that would be amazing.