### PR TITLE
Fix sitemap parser

### DIFF
--- a/linkcheck/parser/sitemap.py
+++ b/linkcheck/parser/sitemap.py
@@ -39,7 +39,7 @@ class XmlTagUrlParser(object):
         self.url_data = url_data
         self.loc = False
         self.url = u""
-        data = url_data.get_content()
+        data = url_data.get_raw_content()
         isfinal = True
         try:
             self.parser.Parse(data, isfinal)

--- a/tests/checker/data/sitemap.xml.result
+++ b/tests/checker/data/sitemap.xml.result
@@ -1,0 +1,4 @@
+url http://localhost:%(port)d/%(datadir)s/sitemap.xml
+cache key http://localhost:%(port)d/%(datadir)s/sitemap.xml
+real url http://localhost:%(port)d/%(datadir)s/sitemap.xml
+valid

--- a/tests/checker/test_http_misc.py
+++ b/tests/checker/test_http_misc.py
@@ -26,6 +26,7 @@ class TestHttpMisc (HttpServerTest):
     @need_network
     def test_html (self):
         self.swf_test()
+        self.file_test("sitemap.xml")
 
     def swf_test (self):
         url = self.get_url(u"test.swf")


### PR DESCRIPTION
PyExpat wants bytes on Python 2.  See #323.

This PR also adds a regression test (by reusing the sitemap.xml we had for mimetype detection tests).