### PR TITLE
Explain why these tests are being skipped

### DIFF
--- a/tests/checker/test_news.py
+++ b/tests/checker/test_news.py
@@ -31,7 +31,7 @@ NNTP_INFO = u"200 news.uni-stuttgart.de InterNetNews NNRP server " \
 NNTP_TIMEOUT_SECS = 30
 
 # disabled for now until some stable news server comes up
-@pytest.mark.skipif("True")
+@pytest.mark.skip(reason="disabled for now until some stable news server comes up")
 class TestNews (LinkCheckTest):
     """Test nntp: and news: link checking."""
 


### PR DESCRIPTION
pytest output before this change:

    SKIPPED [3] tests/__init__.py:217: condition: True
    SKIPPED [1] tests/checker/test_news.py:63: condition: True
    SKIPPED [1] tests/checker/test_news.py:41: condition: True
    SKIPPED [1] tests/checker/test_news.py:116: condition: True
    SKIPPED [1] tests/checker/test_news.py:75: condition: True

After:

    SKIPPED [3] tests/__init__.py: disabled for now until some stable news server comes up
    SKIPPED [4] tests/checker/test_news.py: disabled for now until some stable news server comes up