### PR TITLE
Fix test_clamav.py on Python 3

### DIFF
--- a/linkcheck/plugins/viruscheck.py
+++ b/linkcheck/plugins/viruscheck.py
@@ -87,11 +87,11 @@ class ClamdScanner (object):
         """Return a connected socket for sending scan data to it."""
         port = None
         try:
-            self.sock.sendall("STREAM")
+            self.sock.sendall(b"STREAM")
             port = None
             for dummy in range(60):
                 data = self.sock.recv(self.sock_rcvbuf)
-                i = data.find("PORT")
+                i = data.find(b"PORT")
                 if i != -1:
                     port = int(data[i+5:])
                     break
@@ -118,10 +118,10 @@ class ClamdScanner (object):
         self.wsock.close()
         data = self.sock.recv(self.sock_rcvbuf)
         while data:
-            if "FOUND\n" in data:
-                self.infected.append(data)
-            if "ERROR\n" in data:
-                self.errors.append(data)
+            if b"FOUND\n" in data:
+                self.infected.append(data.decode('UTF-8', 'replace'))
+            if b"ERROR\n" in data:
+                self.errors.append(data.decode('UTF-8', 'replace'))
             data = self.sock.recv(self.sock_rcvbuf)
         self.sock.close()
 

--- a/tests/test_clamav.py
+++ b/tests/test_clamav.py
@@ -29,7 +29,7 @@ class TestClamav (unittest.TestCase):
 
     @need_clamav
     def testClean (self):
-        data = ""
+        data = b""
         infected, errors = clamav.scan(data, self.clamav_conf)
         self.assertFalse(infected)
         self.assertFalse(errors)
@@ -37,24 +37,26 @@ class TestClamav (unittest.TestCase):
     @need_clamav
     def testInfected (self):
         # from the clamav test direcotry: the clamav test file as html data
-        data = '<a href="data:application/octet-stream;base64,' \
-           'TVpQAAIAAAAEAA8A//8AALgAAAAhAAAAQAAaAAAAAAAAAAAAAAAAAAAAAAAAAA' \
-           'AAAAAAAAAAAAAAAAAAAAEAALtxEEAAM8BQUIvzU1NQsClAMARmrHn5ujEAeA2t' \
-           'UP9mcA4fvjEA6eX/tAnNIbRMzSFiDAoBAnB2FwIeTgwEL9rMEAAAAAAAAAAAAA' \
-           'AAAAAAwBAAAIAQAAAAAAAAAAAAAAAAAADaEAAA9BAAAAAAAAAAAAAAAAAAAAAA' \
-           'AAAAAAAAS0VSTkVMMzIuRExMAABFeGl0UHJvY2VzcwBVU0VSMzIuRExMAENMQU' \
-           '1lc3NhZ2VCb3hBAOYQAAAAAAAAPz8/P1BFAABMAQEAYUNhQgAAAAAAAAAA4ACO' \
-           'gQsBAhkABAAAAAYAAAAAAABAEAAAABAAAEAAAAAAAEAAABAAAAACAAABAAAAAA' \
-           'AAAAMACgAAAAAAACAAAAAEAAAAAAAAAgAAAAAAEAAAIAAAAAAQAAAQAAAAAAAA' \
-           'EAAAAAAAAAAAAAAAhBAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' \
-           'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' \
-           'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAW0NMQU1BVl' \
-           '0AEAAAABAAAAACAAABAAAAAAAAAAAAAAAAAAAAAAAAwA==">t</a>'
+        data = (
+           b'<a href="data:application/octet-stream;base64,'
+           b'TVpQAAIAAAAEAA8A//8AALgAAAAhAAAAQAAaAAAAAAAAAAAAAAAAAAAAAAAAAA'
+           b'AAAAAAAAAAAAAAAAAAAAEAALtxEEAAM8BQUIvzU1NQsClAMARmrHn5ujEAeA2t'
+           b'UP9mcA4fvjEA6eX/tAnNIbRMzSFiDAoBAnB2FwIeTgwEL9rMEAAAAAAAAAAAAA'
+           b'AAAAAAwBAAAIAQAAAAAAAAAAAAAAAAAADaEAAA9BAAAAAAAAAAAAAAAAAAAAAA'
+           b'AAAAAAAAS0VSTkVMMzIuRExMAABFeGl0UHJvY2VzcwBVU0VSMzIuRExMAENMQU'
+           b'1lc3NhZ2VCb3hBAOYQAAAAAAAAPz8/P1BFAABMAQEAYUNhQgAAAAAAAAAA4ACO'
+           b'gQsBAhkABAAAAAYAAAAAAABAEAAAABAAAEAAAAAAAEAAABAAAAACAAABAAAAAA'
+           b'AAAAMACgAAAAAAACAAAAAEAAAAAAAAAgAAAAAAEAAAIAAAAAAQAAAQAAAAAAAA'
+           b'EAAAAAAAAAAAAAAAhBAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+           b'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+           b'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAW0NMQU1BVl'
+           b'0AEAAAABAAAAACAAABAAAAAAAAAAAAAAAAAAAAAAAAwA==">t</a>'
+        )
         infected, errors = clamav.scan(data, self.clamav_conf)
         # different versions of clamav report different responses, apparently
         acceptable_responses = (
-            ['stream: ClamAV-Test-File(2d1206194bd704385e37000be6113f73:781) FOUND\n'],
-            ['stream: Clamav.Test.File-6(aa15bcf478d165efd2065190eb473bcb:544) FOUND\n'],
+            [u'stream: ClamAV-Test-File(2d1206194bd704385e37000be6113f73:781) FOUND\n'],
+            [u'stream: Clamav.Test.File-6(aa15bcf478d165efd2065190eb473bcb:544) FOUND\n'],
         )
         self.assertIn(infected, acceptable_responses)
         self.assertFalse(errors)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@ deps =
     -rrequirements.txt
     pyftpdlib
     parameterized
-    pdfminer < 20191010
+    py27: pdfminer < 20191010
+    !py27: pdfminer
     pytest-xdist
     pytest-cov
     miniboa


### PR DESCRIPTION
This PR also contains the pdfminer fix mentioned in https://github.com/linkchecker/linkchecker/pull/249#issuecomment-546301773 and should, if cherry-picked, allow the tests to pass on that branch.