### PR TITLE
Enable https checking using a test server

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ miniboa
 parameterized
 pdfminer
 pyftpdlib
+pyopenssl
 pytest
 pytest-xdist
 # for building on osx:

--- a/tests/checker/test_https.py
+++ b/tests/checker/test_https.py
@@ -23,6 +23,8 @@ from tests import need_network
 from .httpserver import HttpsServerTest, CookieRedirectHttpRequestHandler
 from .. import get_file
 
+from linkcheck import httputil
+
 
 class TestHttps(HttpsServerTest):
     """
@@ -63,3 +65,9 @@ class TestHttps(HttpsServerTest):
             sslverify=False
         )
         self.direct(url, resultlines, recursionlevel=0, confargs=confargs)
+
+    def test_x509_to_dict(self):
+        with open(get_file("https_cert.pem"), "rb") as f:
+            cert = crypto.load_certificate(crypto.FILETYPE_PEM, f.read())
+        self.assertEqual(httputil.x509_to_dict(cert)["notAfter"],
+                         "Jan 02 03:04:05 2119 GMT")

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     parameterized
     py27: pdfminer < 20191010
     !py27: pdfminer
+    pyopenssl
     pytest-xdist
     pytest-cov
     miniboa


### PR DESCRIPTION
Previously disabled because it was using Amazon. Verification is disabled because we generate our own certificate.

Also use the generated certificate to test httputil.x509_to_dict() and the fix required for Python 3.
