### PR TITLE
Actually fix TypeError when checking https link

### DIFF
--- a/linkcheck/httputil.py
+++ b/linkcheck/httputil.py
@@ -44,6 +44,7 @@ def x509_to_dict(x509):
     }
     notAfter = x509.get_notAfter()
     if notAfter is not None:
+        notAfter = notAfter.decode()
         parsedtime = asn1_generaltime_to_seconds(notAfter)
         if parsedtime is not None:
             res['notAfter'] = parsedtime.strftime('%b %d %H:%M:%S %Y')


### PR DESCRIPTION
The test was added but not the fix in:
ecd06776 ("Fix TypeError when checking https link and test", 2019-11-11)

Which is caught by the new test when run on Python 3:
```
___________________ TestHttps.test_x509_to_dict__________________
[gw14] linux -- Python 3.6.9 /usr/bin/python3.6
tests/checker/test_https.py:72: in test_x509_to_dict
    self.assertEqual(httputil.x509_to_dict(cert)["notAfter"],
linkcheck/httputil.py:47: in x509_to_dict
    parsedtime = asn1_generaltime_to_seconds(notAfter)
linkcheck/httputil.py:68: in asn1_generaltime_to_seconds
    res = datetime.strptime(timestr, timeformat + 'Z')
E   TypeError: strptime() argument 1 must be str, not bytes
```