### PR TITLE
Require beautifulsoup4 instead of bs4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # required:
-bs4
+beautifulsoup4
 requests >= 2.4
 pyxdg
 dnspython

--- a/setup.py
+++ b/setup.py
@@ -495,7 +495,7 @@ args = dict(
     install_requires = [
         'requests >= 2.4',
         'dnspython',
-        'bs4',
+        'beautifulsoup4',
         'pyxdg',
         'future',
     ],


### PR DESCRIPTION
bs4 is a dummy package managed by the developer of Beautiful Soup to prevent
name squatting. The official name of PyPI’s Beautiful Soup Python package is
beautifulsoup4. The bs4 package ensures that if you type pip install bs4 by
mistake you will end up with Beautiful Soup.

However, for requirements, it's cleaner to use the proper name.
For downstream packaging in Fedora, this avoids the need of packaging
the dummy package.