### PR TITLE
Remove use of Python 2 unicode() and related u prefixes

### DIFF
--- a/linkcheck/bookmarks/chrome.py
+++ b/linkcheck/bookmarks/chrome.py
@@ -34,15 +34,16 @@ def get_profile_dir ():
             try:
                 basedir = get_shell_folder("Local AppData")
             except EnvironmentError:
-                basedir = os.path.join(os.environ["USERPROFILE"], "Local Settings", "Application Data")
-        dirpath = os.path.join(basedir, u"Google", u"Chrome", u"User Data")
+                basedir = os.path.join(os.environ["USERPROFILE"],
+                                       "Local Settings", "Application Data")
+        dirpath = os.path.join(basedir, "Google", "Chrome", "User Data")
     elif os.name == 'posix':
-        basedir = unicode(os.environ["HOME"])
         if sys.platform == 'darwin':
-            dirpath = os.path.join(basedir, u"Library", u"Application Support")
+            dirpath = os.path.join(os.environ["HOME"], "Library",
+                                   "Application Support")
         else:
             dirpath = xdg_config_home
-        dirpath = os.path.join(dirpath, u"Google", u"Chrome")
+        dirpath = os.path.join(dirpath, "Google", "Chrome")
     return dirpath
 
 
@@ -59,7 +60,7 @@ def find_bookmark_file (profile="Default"):
                 return fname
     except Exception:
         pass
-    return u""
+    return ""
 
 
 from .chromium import parse_bookmark_data, parse_bookmark_file

--- a/linkcheck/bookmarks/chromium.py
+++ b/linkcheck/bookmarks/chromium.py
@@ -36,15 +36,16 @@ def get_profile_dir ():
             try:
                 basedir = get_shell_folder("Local AppData")
             except EnvironmentError:
-                basedir = os.path.join(os.environ["USERPROFILE"], "Local Settings", "Application Data")
-        dirpath = os.path.join(basedir, u"Chromium", u"User Data")
+                basedir = os.path.join(os.environ["USERPROFILE"],
+                                       "Local Settings", "Application Data")
+        dirpath = os.path.join(basedir, "Chromium", "User Data")
     elif os.name == 'posix':
-        basedir = unicode(os.environ["HOME"])
         if sys.platform == 'darwin':
-            dirpath = os.path.join(basedir, u"Library", u"Application Support")
+            dirpath = os.path.join(os.environ["HOME"], "Library",
+                                   "Application Support")
         else:
             dirpath = xdg_config_home
-        dirpath = os.path.join(dirpath, u"chromium")
+        dirpath = os.path.join(dirpath, "chromium")
     return dirpath
 
 

--- a/linkcheck/bookmarks/firefox.py
+++ b/linkcheck/bookmarks/firefox.py
@@ -35,10 +35,9 @@ def get_profile_dir ():
     """Return path where all profiles of current user are stored."""
     if os.name == 'nt':
         basedir = unicode(os.environ["APPDATA"], nt_filename_encoding)
-        dirpath = os.path.join(basedir, u"Mozilla", u"Firefox", u"Profiles")
+        dirpath = os.path.join(basedir, "Mozilla", "Firefox", "Profiles")
     elif os.name == 'posix':
-        basedir = unicode(os.environ["HOME"])
-        dirpath = os.path.join(basedir, u".mozilla", u"firefox")
+        dirpath = os.path.join(os.environ["HOME"], ".mozilla", "firefox")
     return dirpath
 
 
@@ -49,14 +48,14 @@ def find_bookmark_file (profile="*.default"):
     could be found.
     """
     try:
-        for dirname in glob.glob(u"%s/%s" % (get_profile_dir(), profile)):
+        for dirname in glob.glob("%s/%s" % (get_profile_dir(), profile)):
             if os.path.isdir(dirname):
                 fname = os.path.join(dirname, "places.sqlite")
                 if os.path.isfile(fname):
                     return fname
     except Exception:
         pass
-    return u""
+    return ""
 
 
 def parse_bookmark_file (filename):

--- a/linkcheck/bookmarks/opera.py
+++ b/linkcheck/bookmarks/opera.py
@@ -30,10 +30,9 @@ def get_profile_dir ():
     """Return path where all profiles of current user are stored."""
     if os.name == 'nt':
         basedir = unicode(os.environ["APPDATA"], nt_filename_encoding)
-        dirpath = os.path.join(basedir, u"Opera", u"Opera")
+        dirpath = os.path.join(basedir, "Opera", "Opera")
     elif os.name == 'posix':
-        basedir = unicode(os.environ["HOME"])
-        dirpath = os.path.join(basedir, u".opera")
+        dirpath = os.path.join(os.environ["HOME"], ".opera")
     return dirpath
 
 

--- a/linkcheck/bookmarks/safari.py
+++ b/linkcheck/bookmarks/safari.py
@@ -27,8 +27,7 @@ except ImportError:
 
 def get_profile_dir ():
     """Return path where all profiles of current user are stored."""
-    basedir = unicode(os.environ["HOME"])
-    return os.path.join(basedir, u"Library", u"Safari")
+    return os.path.join(os.environ["HOME"], "Library", "Safari")
 
 
 def find_bookmark_file ():
@@ -37,16 +36,16 @@ def find_bookmark_file ():
     could be found.
     """
     if sys.platform != 'darwin':
-        return u""
+        return ""
     try:
         dirname = get_profile_dir()
         if os.path.isdir(dirname):
-            fname = os.path.join(dirname, u"Bookmarks.plist")
+            fname = os.path.join(dirname, "Bookmarks.plist")
             if os.path.isfile(fname):
                 return fname
     except Exception:
         pass
-    return u""
+    return ""
 
 
 def parse_bookmark_file (filename):

--- a/linkcheck/checker/fileurl.py
+++ b/linkcheck/checker/fileurl.py
@@ -139,10 +139,7 @@ class FileUrl (urlbase.UrlBase):
             base_url = re.sub("^file://(/?)([a-zA-Z]):", r"file:///\2|", base_url)
             # transform file://path into file:///path
             base_url = re.sub("^file://([^/])", r"file:///\1", base_url)
-        try:
-            self.base_url = unicode(base_url)
-        except NameError:
-            self.base_url = base_url
+        self.base_url = base_url
 
     def build_url (self):
         """

--- a/linkcheck/htmlutil/formsearch.py
+++ b/linkcheck/htmlutil/formsearch.py
@@ -33,16 +33,8 @@ class Form(object):
         self.data[key] = value
 
     def __repr__(self):
-        """Return unicode representation displaying URL and form data."""
-        return unicode(self)
-
-    def __unicode__(self):
-        """Return unicode string displaying URL and form data."""
-        return u"<url=%s data=%s>" % (self.url, self.data)
-
-    def __str__(self):
         """Return string displaying URL and form data."""
-        return unicode(self).encode('utf-8')
+        return "<url=%s data=%s>" % (self.url, self.data)
 
 
 class FormFinder(object):

--- a/linkcheck/strformat.py
+++ b/linkcheck/strformat.py
@@ -56,16 +56,12 @@ def unicode_safe (s, encoding=i18n.default_encoding, errors='replace'):
     @rtype: unicode
     """
     assert s is not None, "argument to unicode_safe was None"
-    if isinstance(s, str_text):
+    if isinstance(s, str):
         # s is already unicode, nothing to do
         return s
-
-    try:
-        return unicode(str(s), encoding, errors)
-    except NameError:  # Python3
-        if isinstance(s, bytes):
-            return s.decode(encoding, errors)
-        return str(s)
+    elif isinstance(s, bytes):
+        return s.decode(encoding, errors)
+    return str(s)
 
 
 def ascii_safe (s):
@@ -158,8 +154,8 @@ def wrap (text, width, **kwargs):
 
 def indent (text, indent_string="  "):
     """Indent each line of text with the given indent string."""
-    lines = str_text(text).splitlines()
-    return os.linesep.join("%s%s" % (indent_string, x) for x in lines)
+    return os.linesep.join("%s%s" % (indent_string, x)
+                           for x in text.splitlines())
 
 
 def get_line_number (s, index):
@@ -322,11 +318,7 @@ def limit (s, length=72):
 
 def strline (s):
     """Display string representation on one line."""
-    try:
-        s = unicode(s)
-    except NameError:
-        pass
-    return strip_control_chars(u"`%s'" % s.replace(u"\n", u"\\n"))
+    return strip_control_chars("`%s'" % s.replace("\n", "\\n"))
 
 
 def format_feature_warning (**kwargs):

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -18,7 +18,6 @@
 Test dummy object.
 """
 
-import sys
 import unittest
 
 from builtins import str
@@ -64,5 +63,3 @@ class TestDummy (unittest.TestCase):
         del dummy[2:3]
         str(dummy)
         repr(dummy)
-        if sys.version_info.major == 2:
-            unicode(dummy)


### PR DESCRIPTION
Several instances for MS Windows left unchanged.

---

The instances in the bookmarks modules can't be part of the existing tests (they haven't been failing under Python 3). They seem simple enough to update, for Linux, not sure about Windows so have left those.
