### PR TITLE
Remove use of the future package

### DIFF
--- a/linkcheck/better_exchook2.py
+++ b/linkcheck/better_exchook2.py
@@ -33,7 +33,6 @@
 
 # https://github.com/albertz/py_better_exchook
 
-from __future__ import print_function
 import sys
 import os
 

--- a/linkcheck/checker/ftpurl.py
+++ b/linkcheck/checker/ftpurl.py
@@ -25,8 +25,6 @@ except ImportError:
     # Python 3
     from io import StringIO
 
-from builtins import bytes
-
 from .. import log, LOG_CHECK, LinkCheckerError, mimeutil
 from . import proxysupport, httpurl, internpaturl, get_index_html
 from .const import WARN_FTP_MISSING_SLASH

--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -40,7 +40,6 @@ import socket
 import select
 from io import BytesIO
 from builtins import str as str_text
-from future.utils import python_2_unicode_compatible
 
 from . import absolute_url, get_url_from
 from .. import (log, LOG_CHECK,
@@ -82,7 +81,6 @@ def url_norm (url, encoding):
         raise LinkCheckerError(msg)
 
 
-@python_2_unicode_compatible
 class UrlBase (object):
     """An URL with additional information like validity etc."""
 

--- a/linkcheck/cmdline.py
+++ b/linkcheck/cmdline.py
@@ -17,7 +17,6 @@
 """
 Utility functions suitable for command line clients.
 """
-from __future__ import print_function
 import sys
 import argparse
 from . import checker, fileutil, strformat, plugins

--- a/linkcheck/configuration/confparse.py
+++ b/linkcheck/configuration/confparse.py
@@ -22,7 +22,6 @@ except ImportError: # Python 2
     from ConfigParser import RawConfigParser
 import os
 from .. import LinkCheckerError, get_link_pat, LOG_CHECK, log, fileutil, plugins, logconf
-from builtins import str
 
 
 def read_multiline (value):

--- a/linkcheck/decorators.py
+++ b/linkcheck/decorators.py
@@ -35,7 +35,6 @@ def h ():
     pass
 
 """
-from __future__ import print_function
 import warnings
 import signal
 import os

--- a/linkcheck/director/console.py
+++ b/linkcheck/director/console.py
@@ -17,7 +17,6 @@
 """
 Helpers for console output.
 """
-from __future__ import print_function
 import sys
 import os
 import time

--- a/linkcheck/i18n.py
+++ b/linkcheck/i18n.py
@@ -33,21 +33,10 @@ default_domain = None
 
 def install_builtin (translator, do_unicode):
     """Install _() and _n() gettext methods into default namespace."""
-    try:
-        import __builtin__ as builtins
-    except ImportError:
-        # Python 3
-        import builtins
-    # Python 3 has no ugettext
-    has_unicode = hasattr(translator, 'ugettext')
-    if do_unicode and has_unicode:
-        builtins.__dict__['_'] = translator.ugettext
-        # also install ngettext
-        builtins.__dict__['_n'] = translator.ungettext
-    else:
-        builtins.__dict__['_'] = translator.gettext
-        # also install ngettext
-        builtins.__dict__['_n'] = translator.ngettext
+    import builtins
+    builtins.__dict__['_'] = translator.gettext
+    # also install ngettext
+    builtins.__dict__['_n'] = translator.ngettext
 
 class Translator (gettext.GNUTranslations):
     """A translation class always installing its gettext methods into the

--- a/linkcheck/loader.py
+++ b/linkcheck/loader.py
@@ -7,7 +7,6 @@ Example usage:
     modules = loader.get_package_modules('plugins')
     plugins = loader.get_plugins(modules, PluginClass)
 """
-from __future__ import print_function
 import os
 import sys
 import zipfile

--- a/linkcheck/logger/html.py
+++ b/linkcheck/logger/html.py
@@ -18,8 +18,6 @@
 A HTML logger.
 """
 
-from __future__ import absolute_import
-
 from html import escape as html_escape
 import os
 import time

--- a/linkcheck/trace.py
+++ b/linkcheck/trace.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-from __future__ import print_function
 import re
 import linecache
 import time

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ beautifulsoup4
 requests >= 2.4
 pyxdg
 dnspython
-future
 # optional:
 argcomplete

--- a/setup.py
+++ b/setup.py
@@ -409,7 +409,6 @@ setup(
         'dnspython',
         'beautifulsoup4',
         'pyxdg',
-        'future',
     ],
     # Commented out since they are untested and not officially supported.
     # See also doc/install.txt for more detailed dependency documentation.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,8 +14,6 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-from __future__ import print_function
-
 import signal
 import subprocess
 import os

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -22,8 +22,6 @@ import unittest
 
 import linkcheck.containers
 
-from builtins import range
-
 
 class TestLFUCache (unittest.TestCase):
     """Test LFU cache implementation."""

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -20,8 +20,6 @@ Test dummy object.
 
 import unittest
 
-from builtins import str
-
 import linkcheck.dummy
 
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -19,9 +19,9 @@ Test update check functionality.
 """
 
 import unittest
+
 from tests import need_network
 import linkcheck.updater
-from builtins import str
 
 
 class TestUpdater (unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -30,5 +30,4 @@ deps =
     requests >= 2.4
     pyxdg
     dnspython
-    future
     {[base]deps}


### PR DESCRIPTION
This is the start of the removal of Python 2 code, fixing deprecation warnings and some other accumulated tidying (step 4). There are going to be a number of PRs. To start, some that can be merged to master without interfering with the parser PRs.
