### PR TITLE
Add test for loginurl

### DIFF
--- a/tests/checker/cgi-bin/input2cookies.py
+++ b/tests/checker/cgi-bin/input2cookies.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python3
+
+import cgi
+from http import cookies
+
+form = cgi.FieldStorage()
+C = cookies.SimpleCookie()
+for field in form:
+    C[field] = form.getvalue(field)
+
+print(C)

--- a/tests/checker/data/loginform.html
+++ b/tests/checker/data/loginform.html
@@ -1,0 +1,5 @@
+<form action="/tests/checker/cgi-bin/input2cookies.py">
+<input name="login">
+<input name="password">
+<input name="extra_field">
+</form>

--- a/tests/checker/httpserver.py
+++ b/tests/checker/httpserver.py
@@ -19,8 +19,9 @@ Define http test support classes for LinkChecker tests.
 """
 
 from html import escape as html_escape
-from http.server import SimpleHTTPRequestHandler, HTTPServer
+from http.server import CGIHTTPRequestHandler, SimpleHTTPRequestHandler, HTTPServer
 from http.client import HTTPConnection, HTTPSConnection
+import os.path
 import ssl
 import time
 import threading
@@ -300,3 +301,15 @@ class CookieRedirectHttpRequestHandler (NoQueryHttpRequestHandler):
             self.redirect()
         else:
             super(CookieRedirectHttpRequestHandler, self).do_HEAD()
+
+class CGIHandler(CGIHTTPRequestHandler, StoppableHttpRequestHandler):
+    cgi_path = "/tests/checker/cgi-bin/"
+
+    def is_cgi(self):
+        # CGIHTTPRequestHandler.is_cgi() can only handle a single-level path
+        # override so that we can store scripts under /tests/checker
+        if CGIHandler.cgi_path in self.path:
+            self.cgi_info = (CGIHandler.cgi_path,
+                             os.path.relpath(self.path, CGIHandler.cgi_path))
+            return True
+        return False

--- a/tests/checker/test_loginurl.py
+++ b/tests/checker/test_loginurl.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2020 Chris Mayo
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Test director.aggregator.Aggregate.visit_loginurl().
+This includes the retrieval and search of a login form and posting credentials.
+"""
+import re
+
+from .httpserver import HttpServerTest, CGIHandler
+from . import get_test_aggregate
+
+class TestLoginUrl(HttpServerTest):
+    """Test loginurl retrieval, search and posting credentials."""
+
+    def __init__(self, methodName="runTest"):
+        super().__init__(methodName=methodName)
+        self.handler = CGIHandler
+
+    def test_loginurl(self):
+        confargs = {}
+        confargs["loginurl"] = self.get_url("loginform.html")
+        confargs["loginextrafields"] = {"extra_field": "default"}
+        confargs["authentication"] = [{
+            "user": "test_user", "password": "test_password",
+            "pattern": re.compile("^http://localhost.*")
+        }]
+
+        aggregate = get_test_aggregate(confargs, {"expected": ""})
+        aggregate.visit_loginurl()
+
+        self.assertEqual(aggregate.cookies["login"], "test_user")
+        self.assertEqual(aggregate.cookies["password"], "test_password")
+        self.assertEqual(aggregate.cookies["extra_field"], "default")


### PR DESCRIPTION
A new cgi-bin directory is created to identify the scripts to be run by
http.server.CGIHTTPRequestHandler.

---

Adds coverage for director.aggregator.Aggregate.visit_loginurl(). Can be extended to support user or password only testing.
