### PR TITLE
Make _Logger an abstract base class

### DIFF
--- a/linkcheck/logger/__init__.py
+++ b/linkcheck/logger/__init__.py
@@ -130,7 +130,7 @@ class LogStatistics (object):
         self.internal_errors += 1
 
 
-class _Logger (object):
+class _Logger (abc.ABC):
     """
     Base class for logging of checked urls. It defines the public API
     (see below) and offers basic functionality for all loggers.
@@ -158,7 +158,6 @@ class _Logger (object):
     * log_url(url_data)
         Log a checked URL. Called by log_filter_url if do_print is True.
     """
-    __metaclass__ = abc.ABCMeta
 
     # A lowercase name for this logger, usable for option values
     LoggerName = None


### PR DESCRIPTION
The `__metaclass__` syntax is a Python-2-ism.  It was replaced with

    class _Logger (object, metaclass=abc.ABCMeta):

in Python 3.  And then Python 3.4 introduced abc.ABC which is an empty class that has ABCMeta as the metaclass, making it simpler to define abstract base classes.