### PR TITLE
Update README and Dockerfile with Python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2
+FROM python:3
 
 # needed to allow linkchecker create plugin directory and initial configuration file in "home" dir
 ENV HOME /tmp

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ See `doc/install.txt`_ in the source code archive for general information. Excep
 
 .. _doc/install.txt: doc/install.txt
 
-Python 2.7.2 or later is needed. It doesn't work with Python 3 yet, see `#40 <https://github.com/linkchecker/linkchecker/pull/40>`_ for details.
+Python 3 or later is needed.
 
 The version in the pip repository is old. Instead, you can use pip to install the latest release from git: ``pip install git+https://github.com/linkchecker/linkchecker.git@v9.4.0``. See `#4 <https://github.com/linkchecker/linkchecker/pull/4>`_.
 


### PR DESCRIPTION
It is my understanding that Python 3 is now supported.

The current Dockerfile, based on python:2 no longer builds, and fails with this error:

    Running command git clone -q https://github.com/linkchecker/linkchecker.git /tmp/pip-req-build-l0YhGn
      ERROR: Command errored out with exit status 1:
       command: /usr/local/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-l0YhGn/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-l0YhGn/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-req-build-l0YhGn/pip-egg-info
           cwd: /tmp/pip-req-build-l0YhGn/
      Complete output (1 lines):
      This program requires Python 3.5 or later.
      ----------------------------------------
    ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
    WARNING: You are using pip version 20.0.2; however, version 20.1 is available.
    You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.

Updating the Dockerfile to use python:3 works fine. We might also want to remove the line in the README which states that this project does not work with Python 3.
