### PR TITLE
Replace deprecated urllib.parse methods

### DIFF
--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -664,7 +664,7 @@ class UrlBase:
         """
         if self.userinfo:
             # URL itself has authentication info
-            o = urllib.parse.urlparse(self.userinfo)
+            o = urllib.parse.urlparse("//{}@".format(self.userinfo))
             return (o.username, o.password)
         return self.aggregate.config.get_user_password(self.url)
 

--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -383,15 +383,16 @@ class UrlBase:
         Also checks for obfuscated IP addresses.
         """
         # check userinfo@host:port syntax
-        self.userinfo, host = urllib.parse.splituser(self.urlparts[1])
-        port = urlutil.default_ports.get(self.scheme, 0)
-        host, port = urlutil.splitport(host, port=port)
+        o = urllib.parse.urlparse("//%s" % self.urlparts[1])
+        self.userinfo = ":".join([x for x in (o.username, o.password) if x is not None])
+        port = o.port
+        if not port:
+            port = urlutil.default_ports.get(self.scheme, 0)
         if port is None:
             raise LinkCheckerError(_("URL host %(host)r has invalid port") %
-                    {"host": host})
+                    {"host": o.hostname})
         self.port = port
-        # set host lowercase
-        self.host = host.lower()
+        self.host = o.hostname
         if self.scheme in scheme_requires_host:
             if not self.host:
                 raise LinkCheckerError(_("URL has empty hostname"))

--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -663,7 +663,8 @@ class UrlBase:
         """
         if self.userinfo:
             # URL itself has authentication info
-            return urllib.parse.splitpasswd(self.userinfo)
+            o = urllib.parse.urlparse(self.userinfo)
+            return (o.username, o.password)
         return self.aggregate.config.get_user_password(self.url)
 
     def add_url (self, url, line=0, column=0, page=0, name="", base=None):

--- a/linkcheck/url.py
+++ b/linkcheck/url.py
@@ -395,10 +395,10 @@ def url_quote (url, encoding):
 
 def document_quote (document):
     """Quote given document."""
-    doc, query = urllib.parse.splitquery(document)
-    doc = urllib.parse.quote(doc, safe='/=,')
-    if query:
-        return "%s?%s" % (doc, query)
+    o = urllib.parse.urlparse(document)
+    doc = urllib.parse.quote(o.path, safe='/=,')
+    if o.query:
+        return "%s?%s" % (doc, o.query)
     return doc
 
 

--- a/linkcheck/url.py
+++ b/linkcheck/url.py
@@ -188,7 +188,9 @@ def url_fix_host (urlparts, encoding):
     if not urlparts[1]:
         urlparts[2] = urllib.parse.unquote(urlparts[2], encoding=encoding)
         return False
-    userpass, netloc = urllib.parse.splituser(urlparts[1])
+    o = urllib.parse.urlparse("//%s" % urlparts[1])
+    userpass = ":".join([x for x in (o.username, o.password) if x is not None])
+    netloc = ":".join([str(x) for x in (o.hostname, o.port) if x is not None])
     if userpass:
         userpass = urllib.parse.unquote(userpass, encoding=encoding)
     netloc, is_idn = idna_encode(urllib.parse.unquote(netloc, encoding=encoding).lower())

--- a/linkcheck/url.py
+++ b/linkcheck/url.py
@@ -446,13 +446,11 @@ def url_split (url):
     hostname is always lowercased.
     Precondition: url is syntactically correct URI (eg has no whitespace)
     """
-    scheme, netloc = urllib.parse.splittype(url)
-    host, document = urllib.parse.splithost(netloc)
-    port = default_ports.get(scheme, 0)
-    if host:
-        host = host.lower()
-        host, port = splitport(host, port=port)
-    return scheme, host, port, document
+    o = urllib.parse.urlparse(url)
+    port = o.port
+    if port is None:
+        port = default_ports.get(o.scheme, 0)
+    return o.scheme, o.hostname, port, o.path
 
 
 def url_unsplit (parts):


### PR DESCRIPTION
Finally we can get rid of those deprecation warnings. These are local tidy-ups, there may be the potential for a rewrite of these modules using the new methods but that is a bigger job.
