### PR TITLE
Bump version in git to 10.0.0.dev0

### DIFF
--- a/linkcheck/updater.py
+++ b/linkcheck/updater.py
@@ -20,7 +20,7 @@ Function to check for updates.
 import os
 from .configuration import Version as CurrentVersion
 from .url import get_content
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 # Use the Freecode submit file as source since that file gets updated
 # only when releasing a new version.
@@ -72,4 +72,4 @@ def get_online_version():
 
 def is_newer_version(version):
     """Check if given version is newer than current version."""
-    return StrictVersion(version) > StrictVersion(CurrentVersion)
+    return LooseVersion(version) > LooseVersion(CurrentVersion)

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ from distutils.core import Distribution
 from distutils.command.build import build
 
 # the application version
-AppVersion = "9.4.0"
+AppVersion = "10.0.0.dev0"
 # the application name
 AppName = "LinkChecker"
 Description = "check links in web documents or full websites"


### PR DESCRIPTION
It is confusing to have different versions of the code self-identify
with the same version number.  In my experience it's always best to
increment the version number and add a .dev0 suffix right after making a
release.  When it's time to make a new release, you remove the .dev0,
commit, tag that commit, then make second commit that bumps the version
and adds .dev0 back.

This way only releases identify themselves as "version X.Y.Z" with no
.dev0 suffix and it's immediatelly apparent when you've got a prerelease
installed from git.