### PR TITLE
Remove "from builtins import str as str_text"

### DIFF
--- a/linkcheck/checker/fileurl.py
+++ b/linkcheck/checker/fileurl.py
@@ -21,7 +21,6 @@ import re
 import os
 import urllib.parse
 import urllib.request
-from builtins import str as str_text
 from datetime import datetime
 
 from . import urlbase, get_index_html
@@ -202,7 +201,7 @@ class FileUrl(urlbase.UrlBase):
         with links to the files."""
         if self.is_directory():
             data = get_index_html(get_files(self.get_os_filename()))
-            if isinstance(data, str_text):
+            if isinstance(data, str):
                 data = data.encode("iso8859-1", "ignore")
         else:
             data = super(FileUrl, self).read_content()

--- a/linkcheck/checker/itmsservicesurl.py
+++ b/linkcheck/checker/itmsservicesurl.py
@@ -20,8 +20,6 @@ Handle itms-services URLs.
 from . import urlbase
 from .. import log, LOG_CHECK
 
-from builtins import str as str_text
-
 class ItmsServicesUrl(urlbase.UrlBase):
     """Apple iOS application download URLs."""
 
@@ -33,7 +31,7 @@ class ItmsServicesUrl(urlbase.UrlBase):
 
     def local_check(self):
         """Disable content checks."""
-        log.debug(LOG_CHECK, "Checking %s", str_text(self))
+        log.debug(LOG_CHECK, "Checking %s", self)
         pass
 
     def check_content(self):

--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -133,20 +133,20 @@ class UrlBase:
         """
         self.base_ref = base_ref
         if self.base_ref is not None:
-            assert isinstance(self.base_ref, str_text), repr(self.base_ref)
+            assert isinstance(self.base_ref, str), repr(self.base_ref)
         self.base_url = base_url.strip() if base_url else base_url
         if self.base_url is not None:
-            assert isinstance(self.base_url, str_text), repr(self.base_url)
+            assert isinstance(self.base_url, str), repr(self.base_url)
         self.parent_url = parent_url
         if self.parent_url is not None:
-            assert isinstance(self.parent_url, str_text), repr(self.parent_url)
+            assert isinstance(self.parent_url, str), repr(self.parent_url)
         self.recursion_level = recursion_level
         self.aggregate = aggregate
         self.line = line
         self.column = column
         self.page = page
         self.name = name
-        assert isinstance(self.name, str_text), repr(self.name)
+        assert isinstance(self.name, str), repr(self.name)
         self.encoding = url_encoding
         self.extern = extern
         if self.base_ref:
@@ -308,7 +308,7 @@ class UrlBase:
         # URLs with different anchors to have the same content
         self.cache_url = urlutil.urlunsplit(self.urlparts[:4]+[''])
         if self.cache_url is not None:
-            assert isinstance(self.cache_url, str_text), repr(self.cache_url)
+            assert isinstance(self.cache_url, str), repr(self.cache_url)
 
     def check_syntax(self):
         """
@@ -407,7 +407,7 @@ class UrlBase:
         # safe anchor for later checking
         self.anchor = self.urlparts[4]
         if self.anchor is not None:
-            assert isinstance(self.anchor, str_text), repr(self.anchor)
+            assert isinstance(self.anchor, str), repr(self.anchor)
 
     def check_obfuscated_ip(self):
         """Warn if host of this URL is obfuscated IP address."""

--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -25,7 +25,6 @@ import errno
 import socket
 import select
 from io import BytesIO
-from builtins import str as str_text
 
 from . import absolute_url, get_url_from
 from .. import (log, LOG_CHECK,
@@ -224,9 +223,7 @@ class UrlBase:
               "Double result %r (previous %r) for %s", msg, self.result, self)
         else:
             self.has_result = True
-        if not isinstance(msg, str_text):
-            log.warn(LOG_CHECK, "Non-unicode result for %s: %r", self, msg)
-        elif not msg:
+        if not msg:
             log.warn(LOG_CHECK, "Empty result for %s", self)
         self.result = msg
         self.valid = valid
@@ -439,7 +436,7 @@ class UrlBase:
 
     def local_check(self):
         """Local check function can be overridden in subclasses."""
-        log.debug(LOG_CHECK, "Checking %s", str_text(self))
+        log.debug(LOG_CHECK, "Checking %s", self)
         # strict extern URLs should not be checked
         assert not self.extern[1], 'checking strict extern URL'
         # check connection
@@ -456,7 +453,7 @@ class UrlBase:
                 value = _('Hostname not found')
             elif isinstance(exc, UnicodeError):
                 # idna.encode(host) failed
-                value = _('Bad hostname %(host)r: %(msg)s') % {'host': self.host, 'msg': str_text(value)}
+                value = _('Bad hostname %(host)r: %(msg)s') % {'host': self.host, 'msg': value}
             self.set_result(unicode_safe(value), valid=False)
 
     def check_content(self):
@@ -473,7 +470,7 @@ class UrlBase:
             except tuple(ExcList):
                 value = self.handle_exception()
                 self.add_warning(_("could not get content: %(msg)s") %
-                     {"msg": str_text(value)}, tag=WARN_URL_ERROR_GETTING_CONTENT)
+                     {"msg": value}, tag=WARN_URL_ERROR_GETTING_CONTENT)
         return False
 
     def close_connection(self):
@@ -502,11 +499,10 @@ class UrlBase:
             not evalue:
             # EBADF occurs when operating on an already socket
             self.caching = False
-        # format unicode message "<exception name>: <error message>"
-        errmsg = str_text(etype.__name__)
-        uvalue = strformat.unicode_safe(evalue)
-        if uvalue:
-            errmsg += ": %s" % uvalue
+        # format message "<exception name>: <error message>"
+        errmsg = etype.__name__
+        if evalue:
+            errmsg += ": %s" % evalue
         # limit length to 240
         return strformat.limit(errmsg, length=240)
 
@@ -734,7 +730,7 @@ class UrlBase:
         @return: URL info, encoded with the output logger encoding
         @rtype: string
         """
-        s = str_text(self)
+        s = str(self)
         return self.aggregate.config['logger'].encode(s)
 
     def __repr__(self):

--- a/linkcheck/fileutil.py
+++ b/linkcheck/fileutil.py
@@ -24,7 +24,6 @@ import tempfile
 import importlib
 from distutils.spawn import find_executable
 from functools import lru_cache
-from builtins import str as str_text
 
 
 def has_module(name, without_error=True):
@@ -71,7 +70,7 @@ else:
 
 def path_safe(path):
     """Ensure path string is compatible with the platform file system encoding."""
-    if isinstance(path, str_text) and not os.path.supports_unicode_filenames:
+    if isinstance(path, str) and not os.path.supports_unicode_filenames:
         path = path.encode(FSCODING, "replace").decode(FSCODING)
     return path
 

--- a/linkcheck/htmlutil/linkparse.py
+++ b/linkcheck/htmlutil/linkparse.py
@@ -19,7 +19,6 @@ Find link tags in HTML text.
 
 import re
 from .. import strformat, log, LOG_CHECK, url as urlutil
-from builtins import str as str_text
 
 unquote = strformat.unquote
 
@@ -181,11 +180,11 @@ class LinkFinder:
 
     def parse_tag(self, tag, attr, value, name, base, lineno, column):
         """Add given url data to url list."""
-        assert isinstance(tag, str_text), repr(tag)
-        assert isinstance(attr, str_text), repr(attr)
-        assert isinstance(name, str_text), repr(name)
-        assert isinstance(base, str_text), repr(base)
-        assert isinstance(value, str_text) or value is None, repr(value)
+        assert isinstance(tag, str), repr(tag)
+        assert isinstance(attr, str), repr(attr)
+        assert isinstance(name, str), repr(name)
+        assert isinstance(base, str), repr(base)
+        assert isinstance(value, str) or value is None, repr(value)
         # look for meta refresh
         if tag == 'meta' and value:
             mo = refresh_re.match(value)
@@ -209,7 +208,7 @@ class LinkFinder:
 
     def found_url(self, url, name, base, lineno, column):
         """Add newly found URL to queue."""
-        assert isinstance(url, str_text) or url is None, repr(url)
+        assert isinstance(url, str) or url is None, repr(url)
         self.callback(url, line=lineno, column=column, name=name, base=base)
 
 

--- a/linkcheck/lc_cgi.py
+++ b/linkcheck/lc_cgi.py
@@ -28,7 +28,6 @@ import urllib.parse
 from . import configuration, strformat, checker, director, get_link_pat, \
     init_i18n, url as urlutil
 from .decorators import synchronized
-from builtins import str as str_text
 
 # 5 minutes timeout for requests
 MAX_REQUEST_SECONDS = 300
@@ -101,7 +100,7 @@ class ThreadsafeIO:
     @synchronized(_lock)
     def write(self, data):
         """Write given unicode data to buffer."""
-        assert isinstance(data, str_text)
+        assert isinstance(data, str)
         if self.closed:
             raise IOError("Write on closed I/O object")
         if data:

--- a/linkcheck/logger/__init__.py
+++ b/linkcheck/logger/__init__.py
@@ -23,8 +23,8 @@ import datetime
 import time
 import codecs
 import abc
+
 from .. import log, LOG_CHECK, strformat, dummy, configuration, i18n
-from builtins import str as str_text
 
 _ = lambda x: x
 Fields = dict(
@@ -206,7 +206,7 @@ class _Logger(abc.ABC):
 
     def encode(self, s):
         """Encode string with output encoding."""
-        assert isinstance(s, str_text)
+        assert isinstance(s, str)
         return s.encode(self.output_encoding, self.codec_errors)
 
     def init_fileoutput(self, args):

--- a/linkcheck/logger/customxml.py
+++ b/linkcheck/logger/customxml.py
@@ -18,7 +18,6 @@ An XML logger.
 """
 from . import xmllog
 from .. import strformat
-from builtins import str as str_text
 
 
 class CustomXMLLogger(xmllog._XMLLogger):
@@ -48,20 +47,20 @@ class CustomXMLLogger(xmllog._XMLLogger):
         """
         self.xml_starttag('urldata')
         if self.has_part('url'):
-            self.xml_tag("url", str_text(url_data.base_url))
+            self.xml_tag("url", url_data.base_url)
         if url_data.name and self.has_part('name'):
-            self.xml_tag("name", str_text(url_data.name))
+            self.xml_tag("name", url_data.name)
         if url_data.parent_url and self.has_part('parenturl'):
             attrs = {
                 'line': "%s" % url_data.line,
                 'column': "%s" % url_data.column,
             }
-            self.xml_tag("parent", str_text(url_data.parent_url),
+            self.xml_tag("parent", url_data.parent_url,
                          attrs=attrs)
         if url_data.base_ref and self.has_part('base'):
-            self.xml_tag("baseref", str_text(url_data.base_ref))
+            self.xml_tag("baseref", url_data.base_ref)
         if self.has_part("realurl"):
-            self.xml_tag("realurl", str_text(url_data.url))
+            self.xml_tag("realurl", url_data.url)
         if self.has_part("extern"):
             self.xml_tag("extern", "%d" % (1 if url_data.extern else 0))
         if url_data.dltime >= 0 and self.has_part("dltime"):

--- a/linkcheck/logger/text.py
+++ b/linkcheck/logger/text.py
@@ -17,9 +17,9 @@
 The default text logger.
 """
 import time
+
 from . import _Logger
 from .. import ansicolor, strformat, configuration, i18n
-from builtins import str as str_text
 
 
 class TextLogger(_Logger):
@@ -170,7 +170,7 @@ class TextLogger(_Logger):
     def write_real(self, url_data):
         """Write url_data.url."""
         self.write(self.part("realurl") + self.spaces("realurl"))
-        self.writeln(str_text(url_data.url), color=self.colorreal)
+        self.writeln(url_data.url, color=self.colorreal)
 
     def write_dltime(self, url_data):
         """Write url_data.dltime."""

--- a/linkcheck/plugins/markdowncheck.py
+++ b/linkcheck/plugins/markdowncheck.py
@@ -30,7 +30,6 @@ import re
 from . import _ContentPlugin
 from .. import log, LOG_PLUGIN
 
-from builtins import str as str_text
 
 class MarkdownCheck(_ContentPlugin):
     """Markdown parsing plugin."""
@@ -108,7 +107,7 @@ class MarkdownCheck(_ContentPlugin):
         """
         line = content.count('\n', 0, url_pos) + 1
         column = url_pos - content.rfind('\n', 0, url_pos)
-        url_data.add_url(url_text.translate(str_text.maketrans("", "", '\n ')), line=line, column=column)
+        url_data.add_url(url_text.translate(str.maketrans("", "", '\n ')), line=line, column=column)
 
     def _check_by_re(self, url_data, content):
         """ Finds urls by re.

--- a/linkcheck/plugins/parsepdf.py
+++ b/linkcheck/plugins/parsepdf.py
@@ -17,7 +17,6 @@
 Parse links in PDF files with pdfminer.
 """
 from io import BytesIO
-from builtins import str as str_text
 
 from . import _ParserPlugin
 try:
@@ -45,7 +44,7 @@ def search_url(obj, url_data, pageno, seen_objs):
     if isinstance(obj, dict):
         for key, value in obj.items():
             if key == 'URI':
-                if isinstance(value, str_text):
+                if isinstance(value, str):
                     url = value
                 else:
                     # URIs should be 7bit ASCII encoded, but be safe and encode

--- a/linkcheck/strformat.py
+++ b/linkcheck/strformat.py
@@ -37,8 +37,6 @@ import locale
 import pydoc
 from . import i18n
 
-from builtins import str as str_text
-
 
 def unicode_safe(s, encoding=i18n.default_encoding, errors='replace'):
     """Get unicode string without raising encoding errors. Unknown
@@ -68,7 +66,7 @@ def ascii_safe(s):
     @return: encoded ASCII version of s, or None if s was None
     @rtype: string
     """
-    if isinstance(s, str_text):
+    if isinstance(s, str):
         s = s.encode('ascii', 'ignore').decode('ascii')
     return s
 

--- a/linkcheck/url.py
+++ b/linkcheck/url.py
@@ -22,7 +22,6 @@ import re
 import urllib.parse
 
 import requests
-from builtins import str as str_text
 
 from . import log, LOG_CHECK
 
@@ -173,7 +172,7 @@ def idna_encode(host):
     to RFC 3490.
     @raise: UnicodeError if hostname is not properly IDN encoded.
     """
-    if host and isinstance(host, str_text):
+    if host and isinstance(host, str):
         try:
             host.encode('ascii')
             return host, False

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,7 +22,6 @@ import pytest
 from contextlib import contextmanager
 from functools import lru_cache, wraps
 from linkcheck import LinkCheckerInterrupt
-from builtins import str as str_text
 
 
 basedir = os.path.dirname(__file__)
@@ -259,8 +258,8 @@ def get_file(filename=None):
     """
     directory = os.path.join("tests", "checker", "data")
     if filename:
-        return str_text(os.path.join(directory, filename))
-    return str_text(directory)
+        return os.path.join(directory, filename)
+    return directory
 
 
 if __name__ == '__main__':

--- a/tests/checker/__init__.py
+++ b/tests/checker/__init__.py
@@ -252,7 +252,7 @@ class LinkCheckTest(unittest.TestCase):
     def direct(self, url, resultlines, parts=None, recursionlevel=0,
                 confargs=None, url_encoding=None):
         """Check url with expected result."""
-        assert isinstance(url, str_text), repr(url)
+        assert isinstance(url, str), repr(url)
         if confargs is None:
             confargs = {'recursionlevel': recursionlevel}
         else:

--- a/tests/configuration/test_config.py
+++ b/tests/configuration/test_config.py
@@ -20,15 +20,14 @@ Test config parsing.
 import unittest
 import os
 import linkcheck.configuration
-from builtins import str as str_text
 
 
 def get_file(filename=None):
     """Get file name located within 'data' directory."""
     directory = os.path.join("tests", "configuration", "data")
     if filename:
-        return str_text(os.path.join(directory, filename))
-    return str_text(directory)
+        return os.path.join(directory, filename)
+    return directory
 
 
 class TestConfig(unittest.TestCase):


### PR DESCRIPTION
These were used in the conversion to Python 3 to support both Python 2 and 3.

I've been fairly cautious (I hope) in the balance between removing instances of str_text and replacing with str. It may be possible to remove more after closer analysis, they can still be found by searching for isinstance.
