### PR TITLE
Fix internal error on empty HTML files

### DIFF
--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -633,7 +633,9 @@ class UrlBase:
             self.get_raw_content()
             self.soup = htmlsoup.make_soup(self.data)
             # Sometimes soup.original_encoding is None!  Better mangled text
-            # than an internal crash, eh?
+            # than an internal crash, eh?  ISO-8859-1 is a safe fallback in the
+            # sense that any binary blob can be decoded, it'll never cause a
+            # UnicodeDecodeError.
             self.encoding = self.soup.original_encoding or 'ISO-8859-1'
             self.text = self.data.decode(self.encoding)
         return self.text

--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -632,8 +632,10 @@ class UrlBase:
         if self.text is None:
             self.get_raw_content()
             self.soup = htmlsoup.make_soup(self.data)
-            self.text = self.data.decode(self.soup.original_encoding)
-            self.encoding = self.soup.original_encoding
+            # Sometimes soup.original_encoding is None!  Better mangled text
+            # than an internal crash, eh?
+            self.encoding = self.soup.original_encoding or 'ISO-8859-1'
+            self.text = self.data.decode(self.encoding)
         return self.text
 
     def read_content(self):

--- a/tests/checker/data/empty.html.result
+++ b/tests/checker/data/empty.html.result
@@ -1,0 +1,5 @@
+url file://%(curdir)s/%(datadir)s/empty.html
+cache key file://%(curdir)s/%(datadir)s/empty.html
+real url file://%(curdir)s/%(datadir)s/empty.html
+name %(datadir)s/empty.html
+valid

--- a/tests/checker/test_file.py
+++ b/tests/checker/test_file.py
@@ -68,6 +68,9 @@ class TestFile(LinkCheckTest):
     def test_php(self):
         self.file_test("file.php")
 
+    def test_empty(self):
+        self.file_test("empty.html")
+
     @need_word
     def test_word(self):
         confargs = dict(enabledplugins=["WordParser"])


### PR DESCRIPTION
When BeautifulSoup finds an empty file on disk, it sets original_encoding to None.  It doesn't matter what encoding we pick for empty files, so let's just pick one.

I don't know if there are any circumstances where BeautifulSoup might set the encoding to None for a non-empty file.

Closes #392.