### PR TITLE
Update setup.cfg flake8 section

### DIFF
--- a/linkcheck/bookmarks/chrome.py
+++ b/linkcheck/bookmarks/chrome.py
@@ -59,4 +59,4 @@ def find_bookmark_file(profile="Default"):
     return ""
 
 
-from .chromium import parse_bookmark_data, parse_bookmark_file
+from .chromium import parse_bookmark_data, parse_bookmark_file  # noqa: F401

--- a/linkcheck/checker/__init__.py
+++ b/linkcheck/checker/__init__.py
@@ -176,4 +176,4 @@ def get_index_html(urls):
 
 # all the URL classes
 from . import (fileurl, unknownurl, ftpurl, httpurl, dnsurl,
-    mailtourl, telneturl, nntpurl, ignoreurl, itmsservicesurl)
+    mailtourl, telneturl, nntpurl, ignoreurl, itmsservicesurl)  # noqa: E402

--- a/linkcheck/parser/__init__.py
+++ b/linkcheck/parser/__init__.py
@@ -131,4 +131,4 @@ def parse_itms_services(url_data):
             break
 
 
-from .sitemap import parse_sitemap, parse_sitemapindex
+from .sitemap import parse_sitemap, parse_sitemapindex  # noqa: F401

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,26 @@ ignore-bad-ideas = *.mo
 ignore = *.rej
 
 [flake8]
-builtins = _
+filename =
+    *.py
+    ./linkchecker
+builtins =
+    _
+    _n
 max-line-length = 80
+per-file-ignores =
+# In several files imports intentionally cause:
+# E402: module level import not at top of file
+# F401: module imported but unused
+    linkchecker: E402
+    setup.py: E402
+    linkcheck/__init__.py: E402,F401
+    linkcheck/bookmarks/chrome.py: E402
+    linkcheck/checker/httpurl.py: E402
+    linkcheck/htmlutil/htmlsoup.py: E402
+    linkcheck/parser/__init__.py: E402
+    tests/__init__.py: F401
+    
 extend-ignore =
 # https://pep8.readthedocs.org/en/latest/intro.html#error-codes
 # these are ignored by default:

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
 [testenv:flake8]
 deps = flake8
 skip_install = true
-commands = flake8 setup.py linkcheck {posargs}
+commands = flake8 linkchecker setup.py linkcheck {posargs}
 
 [testenv:check-manifest]
 deps = check-manifest


### PR DESCRIPTION
- Prevent "F821 undefined name" being caused by gettext prefixes
- Include the main executable when running flake8 from the top directory
  without specifying files

---

Minimal .flake8 to support running flake8 on its own when developing, and always avoid the F821s from gettext. Leaving specifying the objects to be checked by tox means the stand-alone use behaves as the developer expects. Add checking the main linkchecker executable from tox.
