### PR TITLE
Make sure fetching robots.txt uses the configured timeout

### DIFF
--- a/linkcheck/cache/robots_txt.py
+++ b/linkcheck/cache/robots_txt.py
@@ -41,13 +41,13 @@ class RobotsTxt:
         self.roboturl_locks = {}
         self.useragent = useragent
 
-    def allows_url(self, url_data):
+    def allows_url(self, url_data, timeout=None):
         """Ask robots.txt allowance."""
         roboturl = url_data.get_robots_txt_url()
         with self.get_lock(roboturl):
-            return self._allows_url(url_data, roboturl)
+            return self._allows_url(url_data, roboturl, timeout)
 
-    def _allows_url(self, url_data, roboturl):
+    def _allows_url(self, url_data, roboturl, timeout=None):
         """Ask robots.txt allowance. Assumes only single thread per robots.txt
         URL calls this function."""
         with cache_lock:
@@ -56,7 +56,8 @@ class RobotsTxt:
                 rp = self.cache[roboturl]
                 return rp.can_fetch(self.useragent, url_data.url)
             self.misses += 1
-        kwargs = dict(auth=url_data.auth, session=url_data.session)
+        kwargs = dict(auth=url_data.auth, session=url_data.session,
+                      timeout=timeout)
         if hasattr(url_data, "proxy") and hasattr(url_data, "proxy_type"):
             kwargs["proxies"] = {url_data.proxytype: url_data.proxy}
         rp = robotparser2.RobotFileParser(**kwargs)

--- a/linkcheck/checker/httpurl.py
+++ b/linkcheck/checker/httpurl.py
@@ -73,7 +73,9 @@ class HttpUrl(internpaturl.InternPatternUrl, proxysupport.ProxySupport):
         @return: True if access is granted, otherwise False
         @rtype: bool
         """
-        return not self.aggregate.config['robotstxt'] or self.aggregate.robots_txt.allows_url(self)
+        return (not self.aggregate.config['robotstxt']
+                or self.aggregate.robots_txt.allows_url(
+                    self, timeout=self.aggregate.config["timeout"]))
 
     def content_allows_robots(self):
         """

--- a/linkcheck/robotparser2.py
+++ b/linkcheck/robotparser2.py
@@ -35,7 +35,8 @@ class RobotFileParser:
     """This class provides a set of methods to read, parse and answer
     questions about a single robots.txt file."""
 
-    def __init__(self, url='', session=None, proxies=None, auth=None):
+    def __init__(self, url='', session=None, proxies=None, auth=None,
+                 timeout=None):
         """Initialize internal entry lists and store given url and
         credentials."""
         self.set_url(url)
@@ -45,6 +46,7 @@ class RobotFileParser:
             self.session = session
         self.proxies = proxies
         self.auth = auth
+        self.timeout = timeout
         self._reset()
 
     def _reset(self):
@@ -92,6 +94,8 @@ class RobotFileParser:
             kwargs["auth"] = self.auth
         if self.proxies:
             kwargs["proxies"] = self.proxies
+        if self.timeout:
+            kwargs["timeout"] = self.timeout
         try:
             response = self.session.get(self.url, **kwargs)
             response.raise_for_status()


### PR DESCRIPTION
Maybe closes #396?

I'm setting the timeout in the robot parser fetching code.  I can attach with gdb and see the timeout:

```
#69 Frame 0x7fea5052bcf0, for file /home/mg/.local/pipx/venvs/LinkChecker/lib/python3.8/site-packages/requests/sessions.py, line 1298, in request (self=<Session(headers=<CaseInsensitiveDict(_store={'user-agent': ('User-Agent', 'Mozilla/5.0 (compatible; LinkChecker/10.0.0.dev0; +https://linkchecker.github.io/linkchecker/)'), 'accept-encoding': ('Accept-Encoding', 'gzip, deflate'), 'accept': ('Accept', '*/*'), 'connection': ('Connection', 'keep-alive')}) at remote 0x7fea64170550>, auth=None, proxies={}, hooks={'response': []}, params={}, stream=False, verify=True, cert=None, max_redirects=10, trust_env=True, cookies=<RequestsCookieJar(_policy=<DefaultCookiePolicy(netscape=True, rfc2965=False, rfc2109_as_netscape=None, hide_cookie2=False, strict_domain=False, strict_rfc2965_unverifiable=True, strict_ns_unverifiable=False, strict_ns_domain=0, strict_ns_set_initial_dollar=False, strict_ns_set_path=False, secure_protocols=('https', 'wss'), _blocked_domains=(), _allowed_domains=None, _now=1590134282) at remote 0x7fea641...(truncated)
(gdb) py-print timeout
local 'timeout' = 60
```

but if I go deeper

```
#35 Frame 0x7fea5054cb30, for file /home/mg/.local/pipx/venvs/LinkChecker/lib/python3.8/site-packages/urllib3/connectionpool.py, line 381, in _make_request (self=<HTTPSConnectionPool(host='www-dev.tuhh.de', _proxy_host='www-dev.tuhh.de', port=443, headers={}, strict=True, timeout=<Timeout(_connect=<object at remote 0x7fea663db0b0>, _read=<object at remote 0x7fea663db0b0>, total=None, _start_connect=None) at remote 0x7fea19704730>, retries=<Retry(total=3, connect=None, read=None, status=None, redirect=None, status_forcelist=set(), method_whitelist=frozenset({'OPTIONS', 'PUT', 'DELETE', 'GET', 'TRACE', 'HEAD'}), backoff_factor=0, raise_on_redirect=True, raise_on_status=True, history=(), respect_retry_after_header=True, remove_headers_on_redirect=frozenset({'authorization'})) at remote 0x7fea6602fdf0>, pool=<LifoQueue(maxsize=10, queue=<collections.deque at remote 0x7fea380b2040>, mutex=<_thread.lock at remote 0x7fea5c604240>, not_empty=<Condition(_lock=<_thread.lock at remote 0x7fea5c604240>, acquire=<built-in meth...(truncated)
    self._validate_conn(conn)
```

See the `timeout=<Timeout(_connect=<object at remote 0x7fea663db0b0>, _read=<object at remote 0x7fea663db0b0>, total=None, _start_connect=None)`?  Why does it have `total=None`?
This is the part that I don't understand.

And manual testing on the website mentioned in #396 makes results in linkchecker finishing work in 11 minutes 42 seconds.  It shows a URLs timing out after 383.798 seconds, 364.511 seconds, 208.333 seconds, 148.484 seconds, 118.069 seconds.  Why?  Is it limited by timeout * max_retries?

I also see a few URLs succeeding (200 OK) after 62.250 seconds, 60.414 seconds.  That feels weird?  Maybe it timed out fetching robots.txt, then tried the actual URL and succeeded?

So: in theory this PR should make things better, but I cannot be sure it fixes the problem entirely.

(Also, I didn't write any regression tests.  I'm not sure how.)