### PR TITLE
Fix internal error on empty HTML files accessed over HTTP

### DIFF
--- a/linkcheck/checker/httpurl.py
+++ b/linkcheck/checker/httpurl.py
@@ -299,11 +299,7 @@ class HttpUrl(internpaturl.InternPatternUrl, proxysupport.ProxySupport):
                 self.set_result(_("OK"))
 
     def get_content(self):
-        if self.text is None:
-            self.get_raw_content()
-            self.soup = htmlsoup.make_soup(self.data, self.encoding)
-            self.text = self.data.decode(self.soup.original_encoding)
-        return self.text
+        return super().get_content(self.encoding)
 
     def read_content(self):
         """Return data and data size for this URL.

--- a/linkcheck/checker/httpurl.py
+++ b/linkcheck/checker/httpurl.py
@@ -169,6 +169,7 @@ class HttpUrl(internpaturl.InternPatternUrl, proxysupport.ProxySupport):
         self.url_connection = self.session.send(request, **kwargs)
         self.headers = self.url_connection.headers
         self.encoding = self.url_connection.encoding
+        log.debug(LOG_CHECK, "Response encoding %s", self.encoding)
         self._add_ssl_info()
 
     def _add_response_info(self):

--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -636,7 +636,10 @@ class UrlBase:
             # than an internal crash, eh?  ISO-8859-1 is a safe fallback in the
             # sense that any binary blob can be decoded, it'll never cause a
             # UnicodeDecodeError.
+            log.debug(LOG_CHECK, "Beautiful Soup detected %s",
+                      self.soup.original_encoding)
             self.encoding = self.soup.original_encoding or 'ISO-8859-1'
+            log.debug(LOG_CHECK, "Content encoding %s", self.encoding)
             self.text = self.data.decode(self.encoding)
         return self.text
 

--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -628,10 +628,10 @@ class UrlBase:
             self.data = self.download_content()
         return self.data
 
-    def get_content(self):
+    def get_content(self, encoding=None):
         if self.text is None:
             self.get_raw_content()
-            self.soup = htmlsoup.make_soup(self.data)
+            self.soup = htmlsoup.make_soup(self.data, encoding)
             # Sometimes soup.original_encoding is None!  Better mangled text
             # than an internal crash, eh?  ISO-8859-1 is a safe fallback in the
             # sense that any binary blob can be decoded, it'll never cause a

--- a/tests/checker/data/http_empty.html.result
+++ b/tests/checker/data/http_empty.html.result
@@ -1,0 +1,5 @@
+url http://localhost:%(port)d/%(datadir)s/http_empty.html
+cache key http://localhost:%(port)d/%(datadir)s/http_empty.html
+real url http://localhost:%(port)d/%(datadir)s/http_empty.html
+warning Content size is zero.
+valid

--- a/tests/checker/test_http.py
+++ b/tests/checker/test_http.py
@@ -38,6 +38,7 @@ class TestHttp(HttpServerTest):
         self.file_test("http_file.html", confargs=confargs)
         self.file_test("http_utf8.html", confargs=confargs)
         self.file_test("http_url_quote.html", confargs=confargs)
+        self.file_test("http_empty.html", confargs=confargs)
 
     def test_status(self):
         for status in sorted(self.handler.responses.keys()):


### PR DESCRIPTION
This is the http version of issue #392. HttpUrl has it's own get_content() with a decode() (a hint at the possible fix). Let's just check this does cause an error.

Fixes #392.