### PR TITLE
Remove instances of Python 2 unicode

### DIFF
--- a/linkcheck/better_exchook2.py
+++ b/linkcheck/better_exchook2.py
@@ -122,14 +122,14 @@ def pp_extra_info(obj, depthlimit = 3):
 	s = []
 	if hasattr(obj, "__len__"):
 		try:
-			if type(obj) in (str,unicode,list,tuple,dict) and len(obj) <= 5:
+			if type(obj) in (bytes,str,list,tuple,dict) and len(obj) <= 5:
 				pass # don't print len in this case
 			else:
 				s += ["len = " + str(obj.__len__())]
 		except: pass
 	if depthlimit > 0 and hasattr(obj, "__getitem__"):
 		try:
-			if type(obj) in (str,unicode):
+			if type(obj) in (bytes,str):
 				pass # doesn't make sense to get subitems here
 			else:
 				subobj = obj.__getitem__(0)

--- a/linkcheck/bookmarks/chrome.py
+++ b/linkcheck/bookmarks/chrome.py
@@ -18,15 +18,12 @@ import os
 import sys
 from xdg import xdg_config_home
 
-# Windows filename encoding
-nt_filename_encoding="mbcs"
-
 
 def get_profile_dir():
     """Return path where all profiles of current user are stored."""
     if os.name == 'nt':
         if "LOCALAPPDATA" in os.environ:
-            basedir = unicode(os.environ["LOCALAPPDATA"], nt_filename_encoding)
+            basedir = os.environ["LOCALAPPDATA"]
         else:
             # read local appdata directory from registry
             from ..winutil import get_shell_folder

--- a/linkcheck/bookmarks/chromium.py
+++ b/linkcheck/bookmarks/chromium.py
@@ -20,15 +20,11 @@ import json
 from xdg.BaseDirectory import xdg_config_home
 
 
-# Windows filename encoding
-nt_filename_encoding="mbcs"
-
-
 def get_profile_dir():
     """Return path where all profiles of current user are stored."""
     if os.name == 'nt':
         if "LOCALAPPDATA" in os.environ:
-            basedir = unicode(os.environ["LOCALAPPDATA"], nt_filename_encoding)
+            basedir = os.environ["LOCALAPPDATA"]
         else:
             # read local appdata directory from registry
             from ..winutil import get_shell_folder

--- a/linkcheck/bookmarks/firefox.py
+++ b/linkcheck/bookmarks/firefox.py
@@ -27,13 +27,10 @@ except ImportError:
 extension = re.compile(r'/places.sqlite$', re.IGNORECASE)
 
 
-# Windows filename encoding
-nt_filename_encoding="mbcs"
-
 def get_profile_dir():
     """Return path where all profiles of current user are stored."""
     if os.name == 'nt':
-        basedir = unicode(os.environ["APPDATA"], nt_filename_encoding)
+        basedir = os.environ["APPDATA"]
         dirpath = os.path.join(basedir, "Mozilla", "Firefox", "Profiles")
     elif os.name == 'posix':
         dirpath = os.path.join(os.environ["HOME"], ".mozilla", "firefox")

--- a/linkcheck/bookmarks/opera.py
+++ b/linkcheck/bookmarks/opera.py
@@ -15,9 +15,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 import os
 
-# Windows filename encoding
-nt_filename_encoding="mbcs"
-
 # List of possible Opera bookmark files.
 OperaBookmarkFiles = (
   "bookmarks.adr", # for Opera >= 10.0
@@ -28,7 +25,7 @@ OperaBookmarkFiles = (
 def get_profile_dir():
     """Return path where all profiles of current user are stored."""
     if os.name == 'nt':
-        basedir = unicode(os.environ["APPDATA"], nt_filename_encoding)
+        basedir = os.environ["APPDATA"]
         dirpath = os.path.join(basedir, "Opera", "Opera")
     elif os.name == 'posix':
         dirpath = os.path.join(os.environ["HOME"], ".opera")

--- a/tests/checker/test_file.py
+++ b/tests/checker/test_file.py
@@ -28,8 +28,6 @@ from . import LinkCheckTest, get_file
 
 def unzip(filename, targetdir):
     """Unzip given zipfile into targetdir."""
-    if isinstance(targetdir, unicode):
-        targetdir = str(targetdir)
     zf = zipfile.ZipFile(filename)
     for name in zf.namelist():
         if name.endswith('/'):


### PR DESCRIPTION
Instances in MS Windows specific code still need to be fixed. Mark to be
ignored by flake8, find with:

flake8 --disable-noqa --select=F821