### PR TITLE
Include all files in the sdist via MANIFEST.in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ Changelog.linkchecker*
 .tox
 tests/checker/data/https_cert.pem
 tests/checker/data/https_key.pem
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ jobs:
       env: TOXENV=flake8
       before_script:
       after_success:
+    - name: check-manifest
+      env: TOXENV=check-manifest
+      before_script:
+      after_success:
   allow_failures:
     - name: flake8
       env: TOXENV=flake8

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,30 +1,93 @@
-include README.rst COPYING MANIFEST.in
+include *.ini
 include *.md
-include config/linkchecker-completion config/create.sql
-include config/linkcheckerrc
-include config/linkchecker.apache2.conf install-rpm.sh
-include linkchecker.freecode
-include cgi-bin/lc.wsgi cgi-bin/README
+include *.rst
+include *.txt
+include COPYING
+include Dockerfile
+include MANIFEST.in
 include Makefile
-include cgi-bin/lconline/*.html cgi-bin/lconline/*.de cgi-bin/lconline/*.en
-include cgi-bin/lconline/*.js cgi-bin/lconline/*.css cgi-bin/lconline/*.ico
-include po/*.po po/*.mo po/*.pot po/Makefile
-include doc/*.example doc/*.md doc/*.txt
-include doc/html/*.ico
-include doc/html/*.html
-include doc/html/*.txt
-include doc/html/*.png
-include doc/html/*.qhp
-include doc/html/*.qhcp
-include doc/html/Makefile
-include doc/po4a.conf doc/*.po doc/*.pot
-include doc/en/*.1 doc/en/*.5
-include doc/de/*.1 doc/de/*.5
-include doc/Makefile
-include doc/examples/*.sh doc/examples/*.bat doc/examples/*.py
-include doc/examples/linkcheckerrc_loginurl
-include scripts/*.sh scripts/*.py
-# tests
-include robots.txt
-include tests/configuration/data/*.ini
-recursive-include tests *.py *.result *.html *.ico *.txt *.zip *.asc *.css *.xhtml *.sqlite *.adr *.swf *.bin *.markdown *.pdf *.php *.plist *.wml *.xml
+include install-rpm.sh
+include linkchecker.freecode
+include .project
+include .pydevproject
+  doc/web/wokconfig
+
+recursive-include cgi-bin               \
+    *.css                               \
+    *.de                                \
+    *.en                                \
+    *.html                              \
+    *.ico                               \
+    *.js                                \
+    README
+recursive-include config                \
+    *.sql                               \
+    linkchecker-completion              \
+    linkchecker.apache2.conf            \
+    linkcheckerrc
+recursive-include doc                   \
+    *.1                                 \
+    *.5                                 \
+    *.bat                               \
+    *.css                               \
+    *.example                           \
+    *.html                              \
+    *.ico                               \
+    *.jpg                               \
+    *.md                                \
+    *.png                               \
+    *.po                                \
+    *.pot                               \
+    *.py                                \
+    *.qhcp                              \
+    *.qhp                               \
+    *.rej                               \
+    *.sh                                \
+    *.txt                               \
+    *.yaml                              \
+    *.yml                               \
+    Makefile                            \
+    linkcheckerrc_*                     \
+    po4a.conf                           \
+    wokconfig
+recursive-include po                    \
+    *.mo                                \
+    *.po                                \
+    *.pot                               \
+    Makefile
+recursive-include                       \
+    scripts                             \
+    *.sh                                \
+    *.py
+recursive-include tests                 \
+    *.adr                               \
+    *.asc                               \
+    *.bat                               \
+    *.bin                               \
+    *.cer                               \
+    *.css                               \
+    *.doc                               \
+    *.html                              \
+    *.ico                               \
+    *.ini                               \
+    *.markdown                          \
+    *.pdf                               \
+    *.pfx                               \
+    *.php                               \
+    *.plist                             \
+    *.pvk                               \
+    *.py                                \
+    *.result                            \
+    *.sqlite                            \
+    *.swf                               \
+    *.txt                               \
+    *.wml                               \
+    *.xhtml                             \
+    *.xml                               \
+    *.zip                               \
+    Bookmarks
+recursive-include windows               \
+    *.bat                               \
+    *.cer                               \
+    *.pfx                               \
+    *.pvk

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,7 +10,6 @@ include install-rpm.sh
 include linkchecker.freecode
 include .project
 include .pydevproject
-  doc/web/wokconfig
 
 recursive-include cgi-bin               \
     *.css                               \

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -38,9 +38,6 @@ recursive-include doc                   \
     *.po                                \
     *.pot                               \
     *.py                                \
-    *.qhcp                              \
-    *.qhp                               \
-    *.rej                               \
     *.sh                                \
     *.txt                               \
     *.yaml                              \
@@ -61,9 +58,7 @@ recursive-include                       \
 recursive-include tests                 \
     *.adr                               \
     *.asc                               \
-    *.bat                               \
     *.bin                               \
-    *.cer                               \
     *.css                               \
     *.doc                               \
     *.html                              \
@@ -71,10 +66,8 @@ recursive-include tests                 \
     *.ini                               \
     *.markdown                          \
     *.pdf                               \
-    *.pfx                               \
     *.php                               \
     *.plist                             \
-    *.pvk                               \
     *.py                                \
     *.result                            \
     *.sqlite                            \

--- a/Makefile
+++ b/Makefile
@@ -66,14 +66,11 @@ distclean: clean
 	rm -rf $(APPNAME)-$(VERSION)
 	rm -rf coverage dist-stamp python-build-stamp*
 
-MANIFEST: MANIFEST.in setup.py
-	$(PYTHON) setup.py sdist --manifest-only
-
 locale:
 	$(MAKE) -C po
 
 # to build in the current directory
-localbuild: MANIFEST locale
+localbuild: locale
 	$(PYTHON) setup.py build
 
 release: distclean releasecheck filescheck
@@ -122,7 +119,7 @@ chmod:
 	-chmod -R a+rX,u+w,go-w $(CHMODMINUSMINUS) *
 	find . -type d -exec chmod 755 {} \;
 
-dist: locale MANIFEST chmod
+dist: locale chmod
 	rm -f dist/$(ARCHIVE_SOURCE)
 	$(PYTHON) setup.py sdist --formats=tar
 	gzip --best dist/$(APPNAME)-$(VERSION).tar

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,9 @@ python = python
 [bdist_wheel]
 universal = 0
 
+[check-manifest]
+ignore-bad-ideas = *.mo
+
 [flake8]
 builtins = _
 max-line-length = 80

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ universal = 0
 
 [check-manifest]
 ignore-bad-ideas = *.mo
+ignore = *.rej
 
 [flake8]
 builtins = _

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ Setup file for the distuils module.
 
 It includes the following features:
 - creation and installation of configuration files with installation data
-- automatic MANIFEST.in check
 - automatic generation of .mo locale files
 - automatic permission setting on POSIX systems for installed files
 
@@ -263,36 +262,6 @@ def list_message_files(package, suffix=".mo"):
             "share", "locale", localename, "LC_MESSAGES", domainname))
 
 
-def check_manifest():
-    """Snatched from roundup.sf.net.
-    Check that the files listed in the MANIFEST are present when the
-    source is unpacked."""
-    try:
-        f = open('MANIFEST')
-    except Exception:
-        print('\n*** SOURCE WARNING: The MANIFEST file is missing!')
-        return
-    try:
-        manifest = [l.strip() for l in f.readlines() if not l.startswith('#')]
-    finally:
-        f.close()
-    err = [line for line in manifest if not os.path.exists(line)]
-    if err:
-        n = len(manifest)
-        print('\n*** SOURCE WARNING: There are files missing (%d/%d found)!' %
-            (n - len(err), n))
-        print('\nMissing: '.join(err))
-
-
-class MyBuild(build):
-    """Custom build command."""
-
-    def run(self):
-        """Check MANIFEST before building."""
-        check_manifest()
-        build.run(self)
-
-
 class MyClean(clean):
     """Custom clean command."""
 
@@ -306,15 +275,6 @@ class MyClean(clean):
             else:
                 log.warn("'%s' does not exist -- can't clean it", directory)
         clean.run(self)
-
-
-class MySdist(sdist):
-    """Custom sdist command."""
-
-    def get_file_list(self):
-        """Add MANIFEST to the file list."""
-        super(MySdist, self).get_file_list()
-        self.filelist.append("MANIFEST")
 
 
 # scripts
@@ -368,9 +328,7 @@ setup(
     cmdclass = {
         'install_lib': MyInstallLib,
         'install_data': MyInstallData,
-        'build': MyBuild,
         'clean': MyClean,
-        'sdist': MySdist,
     },
     packages = find_packages(include=["linkcheck", "linkcheck.*"]),
     scripts = scripts,

--- a/tox.ini
+++ b/tox.ini
@@ -36,3 +36,8 @@ deps =
 deps = flake8
 skip_install = true
 commands = flake8 setup.py linkcheck {posargs}
+
+[testenv:check-manifest]
+deps = check-manifest
+skip_install = true
+commands = check-manifest


### PR DESCRIPTION
This PR

- gets rid of the `MANIFEST` file generated by custom build commands in setup.py and the Makefile
- updates MANIFEST.in to include ALL THE FILES!
- adds check-manifest to CI so we can be sure MANIFEST.in will always include ALL THE FILES!

Closes #414.