### PR TITLE
Adjust tests for need_network

### DIFF
--- a/tests/checker/test_file.py
+++ b/tests/checker/test_file.py
@@ -22,7 +22,7 @@ import zipfile
 
 import pytest
 
-from tests import need_word, need_pdflib
+from tests import need_network, need_word, need_pdflib
 from . import LinkCheckTest, get_file
 
 
@@ -48,6 +48,7 @@ class TestFile(LinkCheckTest):
     def test_html(self):
         self.file_test("file.html")
 
+    @need_network
     def test_html_url_quote(self):
         self.file_test("file_url_quote.html")
 

--- a/tests/checker/test_http.py
+++ b/tests/checker/test_http.py
@@ -28,17 +28,20 @@ class TestHttp(HttpServerTest):
         self.handler = CookieRedirectHttpRequestHandler
 
     @need_network
-    def test_html(self):
+    def test_html_internet(self):
         confargs = dict(recursionlevel=1)
         self.file_test("http.html", confargs=confargs)
         self.file_test("http_lowercase.html", confargs=confargs)
         self.file_test("http_quotes.html", confargs=confargs)
         self.file_test("http_slash.html", confargs=confargs)
-        self.file_test("http.xhtml", confargs=confargs)
+        self.file_test("http_url_quote.html", confargs=confargs)
+
+    def test_html(self):
+        confargs = dict(recursionlevel=1)
+        self.file_test("http_empty.html", confargs=confargs)
         self.file_test("http_file.html", confargs=confargs)
         self.file_test("http_utf8.html", confargs=confargs)
-        self.file_test("http_url_quote.html", confargs=confargs)
-        self.file_test("http_empty.html", confargs=confargs)
+        self.file_test("http.xhtml", confargs=confargs)
 
     def test_status(self):
         for status in sorted(self.handler.responses.keys()):

--- a/tests/checker/test_https.py
+++ b/tests/checker/test_https.py
@@ -51,7 +51,6 @@ class TestHttps(HttpsServerTest):
         with open(get_file("https_cert.pem"), "wb") as f:
             f.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
 
-    @need_network
     def test_https(self):
         url = self.get_url("")
         resultlines = [


### PR DESCRIPTION
Nice to enable some tests without the internet, important to mark one that can't:

Subject: Mark TestFile.test_html_url_quote as need_network

Else without the internet the test fails, eventually, with:

warning No MX mail host for users.sourceforge.net found
