### PR TITLE
Update GNOME proxy support for GNOME 3 and Python 3

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -2,6 +2,7 @@
 
 Changes:
 - cmdline: Remove options replaced by plugins and made ineffective in 9.0
+- configuration: Update proxy settings support for GNOME 3.
 
 9.4 "just passing by" (released 12.4.2018)
 

--- a/doc/de.po
+++ b/doc/de.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: linkchecker 3.4\n"
-"POT-Creation-Date: 2020-06-04 17:30+0100\n"
+"POT-Creation-Date: 2020-06-05 16:18+0100\n"
 "PO-Revision-Date: 2020-06-04 17:33+0100\n"
 "Last-Translator: Chris Mayo <aklhfex@gmail.com>\n"
 "Language-Team: German - Germany <>\n"
@@ -25,9 +25,10 @@ msgid "LINKCHECKER"
 msgstr "LINKCHECKER"
 
 #. type: TH
-#: en/linkchecker.1:1 en/linkcheckerrc.5:1
-#, no-wrap
-msgid "2020-04-24"
+#: en/linkchecker.1:1
+#, fuzzy, no-wrap
+#| msgid "2020-04-24"
+msgid "2020-06-05"
 msgstr "2020-04-24"
 
 # type: TH
@@ -1116,12 +1117,20 @@ msgstr "PROXY UNTERSTÜTZUNG"
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:303
+#, fuzzy
+#| msgid ""
+#| "To use a proxy on Unix or Windows set the $http_proxy, $https_proxy or "
+#| "$ftp_proxy environment variables to the proxy URL. The URL should be of "
+#| "the form B<http://>[I<user>B<:>I<pass>B<@>]I<host>[B<:>I<port>].  "
+#| "LinkChecker also detects manual proxy settings of Internet Explorer under "
+#| "Windows systems, and gconf or KDE on Linux systems.  On a Mac use the "
+#| "Internet Config to select a proxy."
 msgid ""
 "To use a proxy on Unix or Windows set the $http_proxy, $https_proxy or "
 "$ftp_proxy environment variables to the proxy URL. The URL should be of the "
 "form B<http://>[I<user>B<:>I<pass>B<@>]I<host>[B<:>I<port>].  LinkChecker "
 "also detects manual proxy settings of Internet Explorer under Windows "
-"systems, and gconf or KDE on Linux systems.  On a Mac use the Internet "
+"systems, and GNOME or KDE on Linux systems.  On a Mac use the Internet "
 "Config to select a proxy."
 msgstr ""
 "Um einen Proxy unter Unix oder Windows zu benutzen, setzen Sie die "
@@ -1755,6 +1764,12 @@ msgstr "Copyright \\(co 2000-2014 Bastian Kleineidam"
 #, no-wrap
 msgid "LINKCHECKERRC"
 msgstr "LINKCHECKERRC"
+
+#. type: TH
+#: en/linkcheckerrc.5:1
+#, no-wrap
+msgid "2020-04-24"
+msgstr "2020-04-24"
 
 # type: Plain text
 #. type: Plain text

--- a/doc/de.po
+++ b/doc/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linkchecker 3.4\n"
 "POT-Creation-Date: 2020-06-05 16:18+0100\n"
-"PO-Revision-Date: 2020-06-04 17:33+0100\n"
+"PO-Revision-Date: 2020-06-11 19:31+0100\n"
 "Last-Translator: Chris Mayo <aklhfex@gmail.com>\n"
 "Language-Team: German - Germany <>\n"
 "Language: de_DE\n"
@@ -26,10 +26,9 @@ msgstr "LINKCHECKER"
 
 #. type: TH
 #: en/linkchecker.1:1
-#, fuzzy, no-wrap
-#| msgid "2020-04-24"
+#, no-wrap
 msgid "2020-06-05"
-msgstr "2020-04-24"
+msgstr "2020-06-05"
 
 # type: TH
 #. type: TH
@@ -1117,14 +1116,6 @@ msgstr "PROXY UNTERSTÜTZUNG"
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:303
-#, fuzzy
-#| msgid ""
-#| "To use a proxy on Unix or Windows set the $http_proxy, $https_proxy or "
-#| "$ftp_proxy environment variables to the proxy URL. The URL should be of "
-#| "the form B<http://>[I<user>B<:>I<pass>B<@>]I<host>[B<:>I<port>].  "
-#| "LinkChecker also detects manual proxy settings of Internet Explorer under "
-#| "Windows systems, and gconf or KDE on Linux systems.  On a Mac use the "
-#| "Internet Config to select a proxy."
 msgid ""
 "To use a proxy on Unix or Windows set the $http_proxy, $https_proxy or "
 "$ftp_proxy environment variables to the proxy URL. The URL should be of the "
@@ -1137,8 +1128,8 @@ msgstr ""
 "$http_proxy, $https_proxy oder $ftp_proxy Umgebungsvariablen auf die Proxy "
 "URL. Die URL sollte die Form B<http://>[I<user>B<:>I<pass>B<@>]I<host>[B<:"
 ">I<port>] besitzen. LinkChecker erkennt auch die Proxy-Einstellungen des "
-"Internet Explorers auf einem Windows-System. Auf einem Mac benutzen Sie die "
-"Internet Konfiguration."
+"Internet Explorers auf einem Windows-System, und GNOME oder KDE auf Linux "
+"Systemen. Auf einem Mac benutzen Sie die Internet Konfiguration."
 
 #. type: Plain text
 #: en/linkchecker.1:306

--- a/doc/de/linkchecker.1
+++ b/doc/de/linkchecker.1
@@ -298,12 +298,13 @@ Das untige Beispiel sendet zwei Cookies zu allen URLs die mit
   Set\-cookie: baggage="elitist"; comment="hologram"
 .EE
 .SH "PROXY UNTERSTÜTZUNG"
-To use a proxy on Unix or Windows set the $http_proxy, $https_proxy or
-$ftp_proxy environment variables to the proxy URL. The URL should be of the
-form \fBhttp://\fP[\fIuser\fP\fB:\fP\fIpass\fP\fB@\fP]\fIhost\fP[\fB:\fP\fIport\fP].  LinkChecker
-also detects manual proxy settings of Internet Explorer under Windows
-systems, and GNOME or KDE on Linux systems.  On a Mac use the Internet
-Config to select a proxy.
+Um einen Proxy unter Unix oder Windows zu benutzen, setzen Sie die
+$http_proxy, $https_proxy oder $ftp_proxy Umgebungsvariablen auf die Proxy
+URL. Die URL sollte die Form
+\fBhttp://\fP[\fIuser\fP\fB:\fP\fIpass\fP\fB@\fP]\fIhost\fP[\fB:\fP\fIport\fP] besitzen. LinkChecker
+erkennt auch die Proxy\-Einstellungen des Internet Explorers auf einem
+Windows\-System, und GNOME oder KDE auf Linux Systemen. Auf einem Mac
+benutzen Sie die Internet Konfiguration.
 .PP
 Sie können eine komma\-separierte Liste von Domainnamen in der $no_proxy
 Umgebungsvariable setzen, um alle Proxies für diese Domainnamen zu

--- a/doc/de/linkchecker.1
+++ b/doc/de/linkchecker.1
@@ -3,7 +3,7 @@
 .\" This file was generated with po4a. Translate the source file.
 .\"
 .\"*******************************************************************
-.TH LINKCHECKER 1 2020\-04\-24 LinkChecker "LinkChecker User Manual"
+.TH LINKCHECKER 1 2020\-06\-05 LinkChecker "LinkChecker User Manual"
 .SH NAME
 linkchecker \- Kommandozeilenprogramm zum Prüfen von HTML Dokumenten und
 Webseiten auf ungültige Verknüpfungen
@@ -298,12 +298,12 @@ Das untige Beispiel sendet zwei Cookies zu allen URLs die mit
   Set\-cookie: baggage="elitist"; comment="hologram"
 .EE
 .SH "PROXY UNTERSTÜTZUNG"
-Um einen Proxy unter Unix oder Windows zu benutzen, setzen Sie die
-$http_proxy, $https_proxy oder $ftp_proxy Umgebungsvariablen auf die Proxy
-URL. Die URL sollte die Form
-\fBhttp://\fP[\fIuser\fP\fB:\fP\fIpass\fP\fB@\fP]\fIhost\fP[\fB:\fP\fIport\fP] besitzen. LinkChecker
-erkennt auch die Proxy\-Einstellungen des Internet Explorers auf einem
-Windows\-System. Auf einem Mac benutzen Sie die Internet Konfiguration.
+To use a proxy on Unix or Windows set the $http_proxy, $https_proxy or
+$ftp_proxy environment variables to the proxy URL. The URL should be of the
+form \fBhttp://\fP[\fIuser\fP\fB:\fP\fIpass\fP\fB@\fP]\fIhost\fP[\fB:\fP\fIport\fP].  LinkChecker
+also detects manual proxy settings of Internet Explorer under Windows
+systems, and GNOME or KDE on Linux systems.  On a Mac use the Internet
+Config to select a proxy.
 .PP
 Sie können eine komma\-separierte Liste von Domainnamen in der $no_proxy
 Umgebungsvariable setzen, um alle Proxies für diese Domainnamen zu

--- a/doc/en/linkchecker.1
+++ b/doc/en/linkchecker.1
@@ -1,4 +1,4 @@
-.TH LINKCHECKER 1 2020-04-24 "LinkChecker" "LinkChecker User Manual"
+.TH LINKCHECKER 1 2020-06-05 "LinkChecker" "LinkChecker User Manual"
 .SH NAME
 linkchecker \- command line client to check HTML documents and websites for broken links
 .SH SYNOPSIS
@@ -298,7 +298,7 @@ To use a proxy on Unix or Windows set the $http_proxy, $https_proxy or $ftp_prox
 environment variables to the proxy URL. The URL should be of the form
 \fBhttp://\fP[\fIuser\fP\fB:\fP\fIpass\fP\fB@\fP]\fIhost\fP[\fB:\fP\fIport\fP].
 LinkChecker also detects manual proxy settings of Internet Explorer under
-Windows systems, and gconf or KDE on Linux systems.
+Windows systems, and GNOME or KDE on Linux systems.
 On a Mac use the Internet Config to select a proxy.
 .PP
 You can also set a comma-separated domain list in the $no_proxy environment

--- a/doc/install.txt
+++ b/doc/install.txt
@@ -54,7 +54,8 @@ First, install the required software.
    ClamAv from https://www.clamav.net/
 
 7. *Optional, for GNOME proxy setting parsing:*
-    Python Gtk from http://www.pygtk.org/downloads.html
+    PyGObject and GIO.
+    Best installed from your distribution e.g. ``python3-gi``
 
 8. *Optional, to run the WSGI web interface:*
    Apache from https://httpd.apache.org/

--- a/doc/linkchecker.doc.pot
+++ b/doc/linkchecker.doc.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-06-04 17:30+0100\n"
+"POT-Creation-Date: 2020-06-05 16:18+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,9 +23,9 @@ msgid "LINKCHECKER"
 msgstr ""
 
 #. type: TH
-#: en/linkchecker.1:1 en/linkcheckerrc.5:1
+#: en/linkchecker.1:1
 #, no-wrap
-msgid "2020-04-24"
+msgid "2020-06-05"
 msgstr ""
 
 #. type: TH
@@ -883,7 +883,7 @@ msgid ""
 "$ftp_proxy environment variables to the proxy URL. The URL should be of the "
 "form B<http://>[I<user>B<:>I<pass>B<@>]I<host>[B<:>I<port>].  LinkChecker "
 "also detects manual proxy settings of Internet Explorer under Windows "
-"systems, and gconf or KDE on Linux systems.  On a Mac use the Internet "
+"systems, and GNOME or KDE on Linux systems.  On a Mac use the Internet "
 "Config to select a proxy."
 msgstr ""
 
@@ -1395,6 +1395,12 @@ msgstr ""
 #: en/linkcheckerrc.5:1
 #, no-wrap
 msgid "LINKCHECKERRC"
+msgstr ""
+
+#. type: TH
+#: en/linkcheckerrc.5:1
+#, no-wrap
+msgid "2020-04-24"
 msgstr ""
 
 #. type: Plain text

--- a/doc/web/media/man1/linkchecker.1.html
+++ b/doc/web/media/man1/linkchecker.1.html
@@ -308,7 +308,7 @@ To use a proxy on Unix or Windows set the $http_proxy, $https_proxy or
   form
   <b>http://</b>[<i>user</i><b>:</b><i>pass</i><b>@</b>]<i>host</i>[<b>:</b><i>port</i>].
   LinkChecker also detects manual proxy settings of Internet Explorer under
-  Windows systems, and gconf or KDE on Linux systems. On a Mac use the Internet
+  Windows systems, and GNOME or KDE on Linux systems. On a Mac use the Internet
   Config to select a proxy.
 <p class="Pp">You can also set a comma-separated domain list in the $no_proxy
     environment variables to ignore any proxy settings for these domains.</p>
@@ -518,7 +518,7 @@ Copyright &#x00A9; 2000-2014 Bastian Kleineidam
 </div>
 <table class="foot">
   <tr>
-    <td class="foot-date">2020-04-24</td>
+    <td class="foot-date">2020-06-05</td>
     <td class="foot-os">LinkChecker</td>
   </tr>
 </table>

--- a/linkchecker
+++ b/linkchecker
@@ -84,7 +84,7 @@ To use a proxy on Unix or Windows set $http_proxy, $https_proxy or $ftp_proxy
 to the proxy URL. The URL should be of the form
 "http://[<user>:<pass>@]<host>[:<port>]".
 LinkChecker also detects manual proxy settings of Internet Explorer under
-Windows systems, and gconf or KDE on Linux systems.
+Windows systems, and GNOME or KDE on Linux systems.
 On a Mac use the Internet Config to select a proxy.
 
 LinkChecker honors the $no_proxy environment variable. It can be a list

--- a/setup.py
+++ b/setup.py
@@ -386,7 +386,7 @@ setup(
     # See also doc/install.txt for more detailed dependency documentation.
     # extra_requires = {
     #    "IP country info": ['GeoIP'], # https://pypi.org/project/GeoIP/
-    #    "GNOME proxies": ['pygtk'], # http://www.pygtk.org/downloads.html
+    #    "GNOME proxies": ['PyGObject'], # https://pypi.org/project/PyGObject/
     #    "Bash completion": ['argcomplete'], # https://pypi.org/project/argcomplete/
     #    "Memory debugging": ['meliae'], # https://pypi.org/project/meliae/
     # }


### PR DESCRIPTION
GConf is replaced by dconf and the GSettings API in GNOME 3.

---

I don't have a proxy setup, but the code being replaced definitely won't work.