### PR TITLE
Fix xdg_config_home import in bookmarks/chrome.py

### DIFF
--- a/linkcheck/bookmarks/chrome.py
+++ b/linkcheck/bookmarks/chrome.py
@@ -16,7 +16,7 @@
 
 import os
 import sys
-from xdg import xdg_config_home
+from xdg.BaseDirectory import xdg_config_home
 
 
 def get_profile_dir():


### PR DESCRIPTION
```
>>> from xdg import xdg_config_home
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'xdg_config_home' from 'xdg' (/usr/lib/python3.7/site-packages/xdg/__init__.py)
```

Fix taken from the other bookmarks files.

This file isn't actually used by linkchecker, fix in case it saves anyone time in future.
