### PR TITLE
Tell flake8 to ignore files that should not be checked

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,9 @@ ignore = *.rej
 filename =
     *.py
     ./linkchecker
+extend-exclude =
+    build/
+    _LinkChecker_configdata.py
 builtins =
     _
     _n


### PR DESCRIPTION
The Python files under build/ are mere copies, not worth checking.

_LinkChecker_configdata.py is a generated file, not stored in the VCS,
not really part of the source.