### PR TITLE
Update man page translation and fixes for application translation process

### DIFF
--- a/doc/de.po
+++ b/doc/de.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: linkchecker 3.4\n"
-"POT-Creation-Date: 2016-01-21 12:56+0100\n"
+"POT-Creation-Date: 2020-06-04 17:30+0100\n"
 "PO-Revision-Date: 2013-12-12 21:51+0100\n"
 "Last-Translator: Bastian Kleineidam <calvin@users.sourceforge.net>\n"
 "Language-Team: de <de@li.org>\n"
@@ -22,10 +22,10 @@ msgid "LINKCHECKER"
 msgstr "LINKCHECKER"
 
 #. type: TH
-#: en/linkchecker.1:1
+#: en/linkchecker.1:1 en/linkcheckerrc.5:1
 #, no-wrap
-msgid "2010-07-01"
-msgstr "2010-07-01"
+msgid "2020-04-24"
+msgstr ""
 
 # type: TH
 #. type: TH
@@ -36,10 +36,11 @@ msgstr "LinkChecker"
 
 # type: TH
 #. type: TH
-#: en/linkchecker.1:1
-#, no-wrap
-msgid "LinkChecker commandline usage"
-msgstr "LinkChecker auf der Kommandozeile"
+#: en/linkchecker.1:1 en/linkcheckerrc.5:1
+#, fuzzy, no-wrap
+#| msgid "LinkChecker features"
+msgid "LinkChecker User Manual"
+msgstr "LinkChecker beinhaltet"
 
 # type: SH
 #. type: SH
@@ -60,14 +61,14 @@ msgstr ""
 
 # type: SH
 #. type: SH
-#: en/linkchecker.1:5
+#: en/linkchecker.1:4
 #, no-wrap
 msgid "SYNOPSIS"
 msgstr "SYNTAX"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:7
+#: en/linkchecker.1:8
 msgid "B<linkchecker> [I<options>] [I<file-or-url>]..."
 msgstr "B<linkchecker> [I<Optionen>] [I<Datei-oder-URL>]..."
 
@@ -79,8 +80,9 @@ msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
 # type: TH
-#. type: Plain text
-#: en/linkchecker.1:11
+#. type: TP
+#: en/linkchecker.1:9
+#, no-wrap
 msgid "LinkChecker features"
 msgstr "LinkChecker beinhaltet"
 
@@ -90,7 +92,7 @@ msgstr "LinkChecker beinhaltet"
 #: en/linkchecker.1:17 en/linkchecker.1:19 en/linkchecker.1:21
 #: en/linkchecker.1:23 en/linkchecker.1:25 en/linkchecker.1:27
 #: en/linkchecker.1:29 en/linkchecker.1:31 en/linkchecker.1:33
-#: en/linkchecker.1:458 en/linkchecker.1:462 en/linkchecker.1:464
+#: en/linkchecker.1:467 en/linkchecker.1:471 en/linkchecker.1:473
 #, no-wrap
 msgid "\\(bu"
 msgstr "\\(bu"
@@ -171,24 +173,27 @@ msgid "EXAMPLES"
 msgstr "BEISPIELE"
 
 # type: Plain text
-#. type: Plain text
-#: en/linkchecker.1:38
+#. type: TP
+#: en/linkchecker.1:36
 #, fuzzy, no-wrap
 #| msgid ""
 #| "The most common use checks the given domain recursively, plus any\n"
 #| "URL pointing outside of the domain:\n"
 #| "  B<linkchecker http://www.example.net/>\n"
-msgid ""
-"The most common use checks the given domain recursively:\n"
-"  B<linkchecker http://www.example.com/>\n"
+msgid "The most common use checks the given domain recursively:"
 msgstr ""
 "Der häufigste Gebrauchsfall prüft die angegebene Domäne rekursiv,\n"
 "inklusive aller einzelnen nach außen zeigenden Verknüpfungen:\n"
 "  B<linkchecker http://www.example.net/>\n"
 
+#. type: Plain text
+#: en/linkchecker.1:39
+msgid "B<linkchecker http://www.example.com/>"
+msgstr ""
+
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:41
+#: en/linkchecker.1:42
 msgid ""
 "Beware that this checks the whole site which can have thousands of URLs.  "
 "Use the B<-r> option to restrict the recursion depth."
@@ -198,75 +203,122 @@ msgstr ""
 "Rekursionstiefe zu beschränken."
 
 # type: Plain text
-#. type: Plain text
-#: en/linkchecker.1:44
+#. type: TP
+#: en/linkchecker.1:42
 #, fuzzy, no-wrap
 #| msgid ""
 #| "Don't check B<mailto:> URLs. All other links are checked as usual:\n"
 #| "  B<linkchecker --ignore-url=^mailto: mysite.example.org>\n"
-msgid ""
-"Don't check URLs with B</secret> in its name. All other links are checked as usual:\n"
-"  B<linkchecker --ignore-url=/secret mysite.example.com>\n"
+msgid "Don't check URLs with B</secret> in its name. All other links are checked as usual:"
 msgstr ""
 "Prüfe keine B<mailto:> URLs. Alle anderen Verknüpfungen werden wie üblich geprüft:\n"
 "  B<linkchecker --ignore-url=^mailto: mysite.example.org>\n"
 
-# type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:47
-#, no-wrap
-msgid ""
-"Checking a local HTML file on Unix:\n"
-"  B<linkchecker ../bla.html>\n"
+#: en/linkchecker.1:45
+msgid "B<linkchecker --ignore-url=/secret mysite.example.com>"
+msgstr ""
+
+# type: Plain text
+#. type: TP
+#: en/linkchecker.1:45
+#, fuzzy, no-wrap
+#| msgid ""
+#| "Checking a local HTML file on Unix:\n"
+#| "  B<linkchecker ../bla.html>\n"
+msgid "Checking a local HTML file on Unix:"
 msgstr ""
 "Überprüfung einer lokalen HTML Datei unter Unix:\n"
 "  B<linkchecker ../bla.html>\n"
 
-# type: Plain text
+# type: TH
 #. type: Plain text
-#: en/linkchecker.1:50
-#, no-wrap
-msgid ""
-"Checking a local HTML file on Windows:\n"
-"  B<linkchecker c:\\etemp\\etest.html>\n"
+#: en/linkchecker.1:48
+#, fuzzy
+#| msgid "B<linkcheckerrc>(5)"
+msgid "B<linkchecker ../bla.html>"
+msgstr "B<linkcheckerrc>(5)"
+
+# type: Plain text
+#. type: TP
+#: en/linkchecker.1:48
+#, fuzzy, no-wrap
+#| msgid ""
+#| "Checking a local HTML file on Windows:\n"
+#| "  B<linkchecker c:\\etemp\\etest.html>\n"
+msgid "Checking a local HTML file on Windows:"
 msgstr ""
 "Überprüfung einer lokalen HTML Datei unter Windows:\n"
 "  B<linkchecker c:\\etemp\\etest.html>\n"
 
-# type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:53
-#, no-wrap
-msgid ""
-"You can skip the B<http://> url part if the domain starts with B<www.>:\n"
-"  B<linkchecker www.example.com>\n"
+#: en/linkchecker.1:51
+msgid "B<linkchecker c:\\temp\\test.html>"
+msgstr ""
+
+# type: Plain text
+#. type: TP
+#: en/linkchecker.1:51
+#, fuzzy, no-wrap
+#| msgid ""
+#| "You can skip the B<http://> url part if the domain starts with B<www.>:\n"
+#| "  B<linkchecker www.example.com>\n"
+msgid "You can skip the B<http://> url part if the domain starts with B<www.>:"
 msgstr ""
 "Sie können den B<http://> URL Anteil weglassen wenn die Domäne mit B<www.> beginnt:\n"
 "  B<linkchecker www.example.com>\n"
 
-# type: Plain text
+# type: TH
 #. type: Plain text
-#: en/linkchecker.1:56
+#: en/linkchecker.1:54
+#, fuzzy
+#| msgid "B<linkcheckerrc>(5)"
+msgid "B<linkchecker www.example.com>"
+msgstr "B<linkcheckerrc>(5)"
+
+# type: Plain text
+#. type: TP
+#: en/linkchecker.1:54
 #, fuzzy, no-wrap
 #| msgid ""
 #| "You can skip the B<ftp://> url part if the domain starts with B<ftp.>:\n"
 #| "  B<linkchecker -r0 ftp.example.org>\n"
-msgid ""
-"You can skip the B<ftp://> url part if the domain starts with B<ftp.>:\n"
-"  B<linkchecker -r0 ftp.example.com>\n"
+msgid "You can skip the B<ftp://> url part if the domain starts with B<ftp.>:"
 msgstr ""
 "Sie können den B<ftp://> URL Anteil weglassen wenn die Domäne mit B<ftp.> beginnt:\n"
 "  B<linkchecker -r0 ftp.example.org>\n"
 
-# type: Plain text
+# type: TH
 #. type: Plain text
-#: en/linkchecker.1:59
-#, no-wrap
-msgid ""
-"Generate a sitemap graph and convert it with the graphviz dot utility:\n"
-"  B<linkchecker -odot -v www.example.com | dot -Tps E<gt> sitemap.ps>\n"
+#: en/linkchecker.1:57
+#, fuzzy
+#| msgid "B<linkcheckerrc>(5)"
+msgid "B<linkchecker -r0 ftp.example.com>"
+msgstr "B<linkcheckerrc>(5)"
+
+# type: Plain text
+#. type: TP
+#: en/linkchecker.1:57
+#, fuzzy, no-wrap
+#| msgid ""
+#| "Generate a sitemap graph and convert it with the graphviz dot utility:\n"
+#| "  B<linkchecker -odot -v www.example.com | dot -Tps E<gt> sitemap.ps>\n"
+msgid "Generate a sitemap graph and convert it with the graphviz dot utility:"
 msgstr ""
 "Erzeuge einen Sitemap Graphen und konvertiere ihn mit dem graphviz dot Programm:\n"
+"  B<linkchecker -odot -v www.example.com | dot -Tps E<gt> sitemap.ps>\n"
+
+# type: Plain text
+#. type: Plain text
+#: en/linkchecker.1:60
+#, fuzzy
+#| msgid ""
+#| "Generate a sitemap graph and convert it with the graphviz dot utility:\n"
+#| "  B<linkchecker -odot -v www.example.com | dot -Tps E<gt> sitemap.ps>\n"
+msgid "B<linkchecker -odot -v www.example.com | dot -Tps E<gt> sitemap.ps>"
+msgstr ""
+"Erzeuge einen Sitemap Graphen und konvertiere ihn mit dem graphviz dot "
+"Programm:\n"
 "  B<linkchecker -odot -v www.example.com | dot -Tps E<gt> sitemap.ps>\n"
 
 # type: SH
@@ -337,7 +389,7 @@ msgstr "B<-t>I<NUMMER>, B<--threads=>I<NUMMER>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:76 en/linkcheckerrc.5:47
+#: en/linkchecker.1:76 en/linkcheckerrc.5:48
 #, fuzzy
 #| msgid ""
 #| "Generate no more than the given number of threads. Default number of "
@@ -396,12 +448,19 @@ msgstr "B<-D>I<NAME>, B<--debug=>I<NAME>"
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:94
+#, fuzzy
+#| msgid ""
+#| "Print debugging output for the given logger.  Available loggers are "
+#| "B<cmdline>, B<checking>, B<cache>, B<dns>, B<plugins> and B<all>.  "
+#| "Specifying B<all> is an alias for specifying all available loggers.  The "
+#| "option can be given multiple times to debug with more than one logger.  "
+#| "For accurate results, threading will be disabled during debug runs."
 msgid ""
 "Print debugging output for the given logger.  Available loggers are "
-"B<cmdline>, B<checking>, B<cache>, B<dns>, B<plugins> and B<all>.  "
-"Specifying B<all> is an alias for specifying all available loggers.  The "
-"option can be given multiple times to debug with more than one logger.  For "
-"accurate results, threading will be disabled during debug runs."
+"B<cmdline>, B<checking>, B<cache>, B<dns>, B<plugin> and B<all>.  Specifying "
+"B<all> is an alias for specifying all available loggers.  The option can be "
+"given multiple times to debug with more than one logger.  For accurate "
+"results, threading will be disabled during debug runs."
 msgstr ""
 "Gebe Testmeldungen aus für den angegebenen Logger. Verfügbare Logger sind "
 "B<cmdline>, B<checking>,B<cache>, B<dns>, B<plugins> und B<all>. Die Angabe "
@@ -418,13 +477,20 @@ msgstr "B<-F>I<TYP>[B</>I<ENKODIERUNG>][B</>I<DATEINAME>], B<--file-output=>I<TY
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:103
+#: en/linkchecker.1:104
+#, fuzzy
+#| msgid ""
+#| "Output to a file B<linkchecker-out.>I<TYPE>, B<$HOME/.linkchecker/"
+#| "blacklist> for B<blacklist> output, or I<FILENAME> if specified.  The "
+#| "I<ENCODING> specifies the output encoding, the default is that of your "
+#| "locale.  Valid encodings are listed at B<http://docs.python.org/library/"
+#| "\\:codecs.html#standard-encodings>."
 msgid ""
 "Output to a file B<linkchecker-out.>I<TYPE>, B<$HOME/.linkchecker/blacklist> "
 "for B<blacklist> output, or I<FILENAME> if specified.  The I<ENCODING> "
 "specifies the output encoding, the default is that of your locale.  Valid "
-"encodings are listed at B<http://docs.python.org/library/\\:codecs."
-"html#standard-encodings>."
+"encodings are listed at E<.UR https://docs.python.org/library/codecs."
+"html#standard-encodings> E<.UE .>"
 msgstr ""
 "Ausgabe in eine Datei namens B<linkchecker-out.>I<TYP>, B<$HOME/.linkchecker/"
 "blacklist> bei B<blacklist> Ausgabe, oder I<DATEINAME> falls angegeben. Das "
@@ -434,7 +500,7 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:113
+#: en/linkchecker.1:114
 msgid ""
 "The I<FILENAME> and I<ENCODING> parts of the B<none> output type will be "
 "ignored, else if the file already exists, it will be overwritten.  You can "
@@ -455,40 +521,40 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:113
+#: en/linkchecker.1:114
 #, no-wrap
 msgid "B<--no-status>"
 msgstr "B<--no-status>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:116
+#: en/linkchecker.1:117
 msgid "Do not print check status messages."
 msgstr "Gebe keine Statusmeldungen aus."
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:116
+#: en/linkchecker.1:117
 #, no-wrap
 msgid "B<--no-warnings>"
 msgstr "B<--no-warnings>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:119
+#: en/linkchecker.1:120
 msgid "Don't log warnings. Default is to log warnings."
 msgstr "Gebe keine Warnungen aus. Standard ist die Ausgabe von Warnungen."
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:119
+#: en/linkchecker.1:120
 #, no-wrap
 msgid "B<-o>I<TYPE>[B</>I<ENCODING>], B<--output=>I<TYPE>[B</>I<ENCODING>]"
 msgstr "B<-o>I<TYP>[B</>I<ENKODIERUNG>], B<--output=>I<TYP>[B</>I<ENKODIERUNG>]"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:126
+#: en/linkchecker.1:127
 msgid ""
 "Specify output type as B<text>, B<html>, B<sql>, B<csv>, B<gml>, B<dot>, "
 "B<xml>, B<sitemap>, B<none> or B<blacklist>.  Default type is B<text>. The "
@@ -500,26 +566,31 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:130
+#: en/linkchecker.1:132 en/linkcheckerrc.5:194
+#, fuzzy
+#| msgid ""
+#| "The I<ENCODING> specifies the output encoding, the default is that of "
+#| "your locale. Valid encodings are listed at B<http://docs.python.org/"
+#| "library/codecs.html#standard-encodings>."
 msgid ""
 "The I<ENCODING> specifies the output encoding, the default is that of your "
-"locale. Valid encodings are listed at B<http://docs.python.org/library/\\:"
-"codecs.html#standard-encodings>."
+"locale. Valid encodings are listed at E<.UR https://docs.python.org/library/"
+"codecs.html#standard-encodings> E<.UE .>"
 msgstr ""
 "Das I<ENCODING> gibt die Ausgabekodierung an. Der Standard ist das der "
 "lokalen Spracheinstellung. Gültige Enkodierungen sind aufgelistet unter "
-"B<http://docs.python.org/library/\\:codecs.html#standard-encodings>."
+"B<http://docs.python.org/library/codecs.html#standard-encodings>."
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:130
+#: en/linkchecker.1:132
 #, no-wrap
 msgid "B<-q>, B<--quiet>"
 msgstr "B<-q>, B<--quiet>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:134
+#: en/linkchecker.1:136
 msgid ""
 "Quiet operation, an alias for B<-o none>.  This is only useful with B<-F>."
 msgstr ""
@@ -528,14 +599,14 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:134
+#: en/linkchecker.1:136
 #, no-wrap
 msgid "B<-v>, B<--verbose>"
 msgstr "B<-v>, B<--verbose>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:137
+#: en/linkchecker.1:139
 msgid "Log all checked URLs. Default is to log only errors and warnings."
 msgstr ""
 "Gebe alle geprüften URLs aus. Standard ist es, nur fehlerhafte URLs und "
@@ -543,14 +614,14 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:137
+#: en/linkchecker.1:139
 #, no-wrap
 msgid "B<-W>I<REGEX>, B<--warning-regex=>I<REGEX>"
 msgstr "B<-W>I<REGEX>, B<--warning-regex=>I<REGEX>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:142
+#: en/linkchecker.1:144
 msgid ""
 "Define a regular expression which prints a warning if it matches any content "
 "of the checked link.  This applies only to valid pages, so we can get their "
@@ -562,7 +633,7 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:145
+#: en/linkchecker.1:147
 msgid ""
 "Use this to check for pages that contain some form of error, for example "
 "\"This page has moved\" or \"Oracle Application error\"."
@@ -573,7 +644,7 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:148 en/linkcheckerrc.5:467
+#: en/linkchecker.1:150 en/linkcheckerrc.5:475
 msgid ""
 "Note that multiple values can be combined in the regular expression, for "
 "example \"(This page has moved|Oracle Application error)\"."
@@ -583,27 +654,27 @@ msgstr ""
 "Applikationsfehler)\"."
 
 #. type: Plain text
-#: en/linkchecker.1:150 en/linkchecker.1:165 en/linkchecker.1:178
+#: en/linkchecker.1:152 en/linkchecker.1:167 en/linkchecker.1:180
 msgid "See section B<REGULAR EXPRESSIONS> for more info."
 msgstr "Siehe Abschnitt B<REGULAR EXPRESSIONS> für weitere Infos."
 
 # type: SS
 #. type: SS
-#: en/linkchecker.1:150
+#: en/linkchecker.1:152
 #, no-wrap
 msgid "Checking options"
 msgstr "Optionen zum Prüfen"
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:151
+#: en/linkchecker.1:153
 #, no-wrap
 msgid "B<--cookiefile=>I<FILENAME>"
 msgstr "B<--cookiefile=>I<DATEINAME>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:155
+#: en/linkchecker.1:157
 msgid ""
 "Read a file with initial cookie data. The cookie data format is explained "
 "below."
@@ -613,27 +684,27 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:155
+#: en/linkchecker.1:157
 #, fuzzy, no-wrap
 #| msgid "B<--check-html>"
 msgid "B<--check-extern>"
 msgstr "B<--check-html>"
 
 #. type: Plain text
-#: en/linkchecker.1:158
+#: en/linkchecker.1:160
 msgid "Check external URLs."
 msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:158
+#: en/linkchecker.1:160
 #, no-wrap
 msgid "B<--ignore-url=>I<REGEX>"
 msgstr "B<--ignore-url=>I<REGEX>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:161
+#: en/linkchecker.1:163
 msgid ""
 "URLs matching the given regular expression will be ignored and not checked."
 msgstr ""
@@ -642,20 +713,20 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:163 en/linkchecker.1:176
+#: en/linkchecker.1:165 en/linkchecker.1:178
 msgid "This option can be given multiple times."
 msgstr "Diese Option kann mehrmals angegeben werden."
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:165
+#: en/linkchecker.1:167
 #, no-wrap
 msgid "B<-N>I<STRING>, B<--nntp-server=>I<STRING>"
 msgstr "B<-N>I<NAME>, B<--nntp-server=>I<NAME>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:170 en/linkcheckerrc.5:34
+#: en/linkchecker.1:172 en/linkcheckerrc.5:35
 msgid ""
 "Specify an NNTP server for B<news:> links. Default is the environment "
 "variable B<NNTP_SERVER>. If no host is given, only the syntax of the link is "
@@ -667,14 +738,14 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:170
+#: en/linkchecker.1:172
 #, no-wrap
 msgid "B<--no-follow-url=>I<REGEX>"
 msgstr "B<--no-follow-url=>I<REGEX>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:174
+#: en/linkchecker.1:176
 msgid ""
 "Check but do not recurse into URLs matching the given regular expression."
 msgstr ""
@@ -683,14 +754,14 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:178
+#: en/linkchecker.1:180
 #, no-wrap
 msgid "B<-p>, B<--password>"
 msgstr "B<-p>, B<--password>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:183
+#: en/linkchecker.1:185
 msgid ""
 "Read a password from console and use it for HTTP and FTP authorization.  For "
 "FTP the default password is B<anonymous@>. For HTTP there is no default "
@@ -702,14 +773,14 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:183
+#: en/linkchecker.1:185
 #, no-wrap
 msgid "B<-r>I<NUMBER>, B<--recursion-level=>I<NUMBER>"
 msgstr "B<-r>I<NUMMER>, B<--recursion-level=>I<NUMMER>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:188 en/linkcheckerrc.5:41
+#: en/linkchecker.1:190 en/linkcheckerrc.5:42
 msgid ""
 "Check recursively all links up to given depth.  A negative depth will enable "
 "infinite recursion.  Default depth is infinite."
@@ -719,14 +790,14 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:188
+#: en/linkchecker.1:190
 #, no-wrap
 msgid "B<--timeout=>I<NUMBER>"
 msgstr "B<--timeout=>I<NUMMER>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:192 en/linkcheckerrc.5:53
+#: en/linkchecker.1:194 en/linkcheckerrc.5:54
 msgid ""
 "Set the timeout for connection attempts in seconds. The default timeout is "
 "60 seconds."
@@ -736,14 +807,14 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:192
+#: en/linkchecker.1:194
 #, no-wrap
 msgid "B<-u>I<STRING>, B<--user=>I<STRING>"
 msgstr "B<-u>I<NAME>, B<--user=>I<NAME>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:197
+#: en/linkchecker.1:199
 msgid ""
 "Try the given username for HTTP and FTP authorization.  For FTP the default "
 "username is B<anonymous>. For HTTP there is no default username. See also B<-"
@@ -755,13 +826,13 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:197
+#: en/linkchecker.1:199
 #, no-wrap
 msgid "B<--user-agent=>I<STRING>"
 msgstr "B<--user-agent=>I<STRING>"
 
 #. type: Plain text
-#: en/linkchecker.1:202 en/linkcheckerrc.5:67
+#: en/linkchecker.1:204 en/linkcheckerrc.5:68
 msgid ""
 "Specify the User-Agent string to send to the HTTP server, for example "
 "\"Mozilla/4.0\". The default is \"LinkChecker/X.Y\" where X.Y is the current "
@@ -773,18 +844,23 @@ msgstr ""
 
 # type: SH
 #. type: SH
-#: en/linkchecker.1:203
+#: en/linkchecker.1:205
 #, no-wrap
 msgid "CONFIGURATION FILES"
 msgstr "KONFIGURATIONSDATEIEN"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:207
+#: en/linkchecker.1:211
+#, fuzzy
+#| msgid ""
+#| "Configuration files can specify all options above. They can also specify "
+#| "some options that cannot be set on the command line.  See "
+#| "B<linkcheckerrc>(5) for more info."
 msgid ""
 "Configuration files can specify all options above. They can also specify "
 "some options that cannot be set on the command line.  See "
-"B<linkcheckerrc>(5) for more info."
+"B<linkcheckerrc>(5)  for more info."
 msgstr ""
 "Konfigurationsdateien können alle obigen Optionen enthalten. Sie können "
 "zudem Optionen enthalten, welche nicht auf der Kommandozeile gesetzt werden "
@@ -792,14 +868,14 @@ msgstr ""
 
 # type: SH
 #. type: SH
-#: en/linkchecker.1:208
+#: en/linkchecker.1:212
 #, no-wrap
 msgid "OUTPUT TYPES"
 msgstr "AUSGABETYPEN"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:212
+#: en/linkchecker.1:216
 msgid ""
 "Note that by default only errors and warnings are logged.  You should use "
 "the B<--verbose> option to get the complete URL list, especially when "
@@ -811,27 +887,27 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:213
+#: en/linkchecker.1:217
 #, no-wrap
 msgid "B<text>"
 msgstr "B<text>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:216
+#: en/linkchecker.1:220
 msgid "Standard text logger, logging URLs in keyword: argument fashion."
 msgstr "Standard Textausgabe in \"Schlüssel: Wert\"-Form."
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:216
+#: en/linkchecker.1:220
 #, no-wrap
 msgid "B<html>"
 msgstr "B<html>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:221
+#: en/linkchecker.1:225
 msgid ""
 "Log URLs in keyword: argument fashion, formatted as HTML.  Additionally has "
 "links to the referenced pages. Invalid URLs have HTML and CSS syntax check "
@@ -843,96 +919,100 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:221
+#: en/linkchecker.1:225
 #, no-wrap
 msgid "B<csv>"
 msgstr "B<csv>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:224
+#: en/linkchecker.1:228
 msgid "Log check result in CSV format with one URL per line."
 msgstr "Gebe Prüfresultat in CSV-Format aus mit einer URL pro Zeile."
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:224
+#: en/linkchecker.1:228
 #, no-wrap
 msgid "B<gml>"
 msgstr "B<gml>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:227
+#: en/linkchecker.1:231
 msgid "Log parent-child relations between linked URLs as a GML sitemap graph."
 msgstr ""
 "Gebe Vater-Kind Beziehungen zwischen verknüpften URLs als GML Graphen aus."
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:227
+#: en/linkchecker.1:231
 #, no-wrap
 msgid "B<dot>"
 msgstr "B<dot>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:230
+#: en/linkchecker.1:234
 msgid "Log parent-child relations between linked URLs as a DOT sitemap graph."
 msgstr ""
 "Gebe Vater-Kind Beziehungen zwischen verknüpften URLs als DOT Graphen aus."
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:230
+#: en/linkchecker.1:234
 #, no-wrap
 msgid "B<gxml>"
 msgstr "B<gxml>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:233
+#: en/linkchecker.1:237
 msgid "Log check result as a GraphXML sitemap graph."
 msgstr "Gebe Prüfresultat als GraphXML-Datei aus."
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:233
+#: en/linkchecker.1:237
 #, no-wrap
 msgid "B<xml>"
 msgstr "B<xml>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:236
+#: en/linkchecker.1:240
 msgid "Log check result as machine-readable XML."
 msgstr "Gebe Prüfresultat als maschinenlesbare XML-Datei aus."
 
 #. type: TP
-#: en/linkchecker.1:236
+#: en/linkchecker.1:240
 #, no-wrap
 msgid "B<sitemap>"
 msgstr "B<sitemap>"
 
 #. type: Plain text
-#: en/linkchecker.1:240
+#: en/linkchecker.1:245
+#, fuzzy
+#| msgid ""
+#| "Log check result as an XML sitemap whose protocol is documented at "
+#| "B<http://www.sitemaps.org/protocol.html>."
 msgid ""
-"Log check result as an XML sitemap whose protocol is documented at B<http://"
-"www.sitemaps.org/protocol.html>."
+"Log check result as an XML sitemap whose protocol is documented at E<.UR "
+"https://www.sitemaps.org/protocol.html> E<.UE .>"
 msgstr ""
 "Protokolliere Prüfergebnisse als XML Sitemap dessen Format unter B<http://"
 "www.sitemaps.org/protocol.html> dokumentiert ist."
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:240
+#: en/linkchecker.1:245
 #, no-wrap
 msgid "B<sql>"
 msgstr "B<sql>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:244
+#: en/linkchecker.1:249
 msgid ""
 "Log check result as SQL script with INSERT commands. An example script to "
 "create the initial SQL table is included as create.sql."
@@ -943,14 +1023,14 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:244
+#: en/linkchecker.1:249
 #, no-wrap
 msgid "B<blacklist>"
 msgstr "B<blacklist>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:249
+#: en/linkchecker.1:254
 msgid ""
 "Suitable for cron jobs. Logs the check result into a file B<~/.linkchecker/"
 "blacklist> which only contains entries with invalid URLs and the number of "
@@ -962,37 +1042,41 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:249
+#: en/linkchecker.1:254
 #, no-wrap
 msgid "B<none>"
 msgstr "B<none>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:252
+#: en/linkchecker.1:257
 msgid "Logs nothing. Suitable for debugging or checking the exit code."
 msgstr "Gibt nichts aus. Für Debugging oder Prüfen des Rückgabewerts geeignet."
 
 # type: SH
 #. type: SH
-#: en/linkchecker.1:253
+#: en/linkchecker.1:258
 #, no-wrap
 msgid "REGULAR EXPRESSIONS"
 msgstr "REGULÄRE AUSDRÜCKE"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:256
+#: en/linkchecker.1:264
+#, fuzzy
+#| msgid ""
+#| "LinkChecker accepts Python regular expressions.  See B<http://docs.python."
+#| "org/\\:howto/regex.html> for an introduction."
 msgid ""
-"LinkChecker accepts Python regular expressions.  See B<http://docs.python."
-"org/\\:howto/regex.html> for an introduction."
+"LinkChecker accepts Python regular expressions.  See E<.UR https://docs."
+"python.org/howto/regex.html> E<.UE> for an introduction."
 msgstr ""
 "LinkChecker akzeptiert Pythons reguläre Ausdrücke. Siehe B<http://docs."
 "python.org/\\:howto/regex.html> für eine Einführung."
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:259
+#: en/linkchecker.1:267
 msgid ""
 "An addition is that a leading exclamation mark negates the regular "
 "expression."
@@ -1002,14 +1086,14 @@ msgstr ""
 
 # type: SH
 #. type: SH
-#: en/linkchecker.1:260
+#: en/linkchecker.1:268
 #, no-wrap
 msgid "COOKIE FILES"
 msgstr "COOKIE-DATEIEN"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:263
+#: en/linkchecker.1:271
 msgid ""
 "A cookie file contains standard HTTP header (RFC 2616) data with the "
 "following possible names:"
@@ -1019,33 +1103,33 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:264
+#: en/linkchecker.1:272
 #, no-wrap
 msgid "B<Host> (required)"
 msgstr "B<Host> (erforderlich)"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:267
+#: en/linkchecker.1:275
 msgid "Sets the domain the cookies are valid for."
 msgstr "Setzt die Domäne für die die Cookies gültig sind."
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:267
+#: en/linkchecker.1:275
 #, no-wrap
 msgid "B<Path> (optional)"
 msgstr "B<Path> (optional)"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:270
+#: en/linkchecker.1:278
 msgid "Gives the path the cookies are value for; default path is B</>."
 msgstr "Gibt den Pfad für den die Cookies gültig sind; Standardpfad ist B</>."
 
 # type: TP
 #. type: TP
-#: en/linkchecker.1:270
+#: en/linkchecker.1:278
 #, fuzzy, no-wrap
 #| msgid "B<Host> (required)"
 msgid "B<Set-cookie> (required)"
@@ -1053,19 +1137,19 @@ msgstr "B<Host> (erforderlich)"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:273
+#: en/linkchecker.1:281
 msgid "Set cookie name/value. Can be given more than once."
 msgstr "Setzt den Cookie Name/Wert. Kann mehrmals angegeben werden."
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:275
+#: en/linkchecker.1:283
 msgid "Multiple entries are separated by a blank line."
 msgstr "Mehrere Einträge sind durch eine Leerzeile zu trennen."
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:279
+#: en/linkchecker.1:287
 msgid ""
 "The example below will send two cookies to all URLs starting with B<http://"
 "example.com/hello/> and one to all URLs starting with B<https://example.org/"
@@ -1077,13 +1161,18 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:284
-#, no-wrap
+#: en/linkchecker.1:292
+#, fuzzy, no-wrap
+#| msgid ""
+#| " Host: example.com\n"
+#| " Path: /hello\n"
+#| " Set-cookie: ID=\"smee\"\n"
+#| " Set-cookie: spam=\"egg\"\n"
 msgid ""
-" Host: example.com\n"
-" Path: /hello\n"
-" Set-cookie: ID=\"smee\"\n"
-" Set-cookie: spam=\"egg\"\n"
+"  Host: example.com\n"
+"  Path: /hello\n"
+"  Set-cookie: ID=\"smee\"\n"
+"  Set-cookie: spam=\"egg\"\n"
 msgstr ""
 " Host: example.com\n"
 " Path: /hello\n"
@@ -1092,15 +1181,15 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:287
+#: en/linkchecker.1:295
 #, fuzzy, no-wrap
 #| msgid ""
 #| " Scheme: https\n"
 #| " Host: example.org\n"
 #| " Set-cookie: baggage=\"elitist\"; comment=\"hologram\"\n"
 msgid ""
-" Host: example.org\n"
-" Set-cookie: baggage=\"elitist\"; comment=\"hologram\"\n"
+"  Host: example.org\n"
+"  Set-cookie: baggage=\"elitist\"; comment=\"hologram\"\n"
 msgstr ""
 " Scheme: https\n"
 " Host: example.org\n"
@@ -1108,14 +1197,14 @@ msgstr ""
 
 # type: SH
 #. type: SH
-#: en/linkchecker.1:288
+#: en/linkchecker.1:296
 #, no-wrap
 msgid "PROXY SUPPORT"
 msgstr "PROXY UNTERSTÜTZUNG"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:295
+#: en/linkchecker.1:303
 #, fuzzy
 #| msgid ""
 #| "To use a proxy on Unix or Windows set the $http_proxy, $https_proxy or "
@@ -1139,7 +1228,7 @@ msgstr ""
 "Internet Konfiguration."
 
 #. type: Plain text
-#: en/linkchecker.1:298
+#: en/linkchecker.1:306
 msgid ""
 "You can also set a comma-separated domain list in the $no_proxy environment "
 "variables to ignore any proxy settings for these domains."
@@ -1149,52 +1238,58 @@ msgstr ""
 "ignorieren."
 
 # type: Plain text
-#. type: Plain text
-#: en/linkchecker.1:300
+#. type: TP
+#: en/linkchecker.1:306
+#, no-wrap
 msgid "Setting a HTTP proxy on Unix for example looks like this:"
 msgstr "Einen HTTP-Proxy unter Unix anzugeben sieht beispielsweise so aus:"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:302
-#, no-wrap
-msgid "  export http_proxy=\"http://proxy.example.com:8080\"\n"
+#: en/linkchecker.1:310
+#, fuzzy
+#| msgid "  export http_proxy=\"http://proxy.example.com:8080\"\n"
+msgid "B<export http_proxy=\"http://proxy.example.com:8080\">"
 msgstr "  export http_proxy=\"http://proxy.example.com:8080\"\n"
 
 # type: Plain text
-#. type: Plain text
-#: en/linkchecker.1:304
+#. type: TP
+#: en/linkchecker.1:310
+#, no-wrap
 msgid "Proxy authentication is also supported:"
 msgstr "Proxy-Authentifizierung wird ebenfalls unterstützt:"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:306
-#, no-wrap
-msgid "  export http_proxy=\"http://user1:mypass@proxy.example.org:8081\"\n"
+#: en/linkchecker.1:314
+#, fuzzy
+#| msgid "  export http_proxy=\"http://user1:mypass@proxy.example.org:8081\"\n"
+msgid "B<export http_proxy=\"http://user1:mypass@proxy.example.org:8081\">"
 msgstr "  export http_proxy=\"http://user1:mypass@proxy.example.org:8081\"\n"
 
 # type: Plain text
-#. type: Plain text
-#: en/linkchecker.1:308
+#. type: TP
+#: en/linkchecker.1:314
+#, no-wrap
 msgid "Setting a proxy on the Windows command prompt:"
 msgstr "Setzen eines Proxies unter der Windows Befehlszeile:"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:310
-#, no-wrap
-msgid "  set http_proxy=http://proxy.example.com:8080\n"
+#: en/linkchecker.1:318
+#, fuzzy
+#| msgid "  set http_proxy=http://proxy.example.com:8080\n"
+msgid "B<set http_proxy=http://proxy.example.com:8080>"
 msgstr "  set http_proxy=http://proxy.example.com:8080\n"
 
 #. type: SH
-#: en/linkchecker.1:311
+#: en/linkchecker.1:318
 #, no-wrap
 msgid "PERFORMED CHECKS"
 msgstr "Durchgeführte Prüfungen"
 
 #. type: Plain text
-#: en/linkchecker.1:317
+#: en/linkchecker.1:324
 msgid ""
 "All URLs have to pass a preliminary syntax test. Minor quoting mistakes will "
 "issue a warning, all other invalid syntax issues are errors.  After the "
@@ -1208,13 +1303,13 @@ msgstr ""
 "beschrieben."
 
 #. type: TP
-#: en/linkchecker.1:318
+#: en/linkchecker.1:324
 #, no-wrap
 msgid "HTTP links (B<http:>, B<https:>)"
 msgstr "HTTP Verknüpfungen (B<http:>, B<https:>)"
 
 #. type: Plain text
-#: en/linkchecker.1:325
+#: en/linkchecker.1:331
 #, fuzzy
 #| msgid ""
 #| "After connecting to the given HTTP server the given path or query is "
@@ -1235,18 +1330,18 @@ msgstr ""
 "Fehler ausgegeben."
 
 #. type: Plain text
-#: en/linkchecker.1:327
+#: en/linkchecker.1:333
 msgid "HTML page contents are checked for recursion."
 msgstr "Der Inhalt von HTML-Seiten wird rekursiv geprüft."
 
 #. type: TP
-#: en/linkchecker.1:327
+#: en/linkchecker.1:333
 #, no-wrap
 msgid "Local files (B<file:>)"
 msgstr "Lokale Dateien (B<file:>)"
 
 #. type: Plain text
-#: en/linkchecker.1:332
+#: en/linkchecker.1:338
 msgid ""
 "A regular, readable file that can be opened is valid. A readable directory "
 "is also valid. All other files, for example device files, unreadable or non-"
@@ -1258,18 +1353,18 @@ msgstr ""
 "Fehler."
 
 #. type: Plain text
-#: en/linkchecker.1:334
+#: en/linkchecker.1:340
 msgid "HTML or other parseable file contents are checked for recursion."
 msgstr "HTML- oder andere untersuchbare Dateiinhalte werden rekursiv geprüft."
 
 #. type: TP
-#: en/linkchecker.1:334
+#: en/linkchecker.1:340
 #, no-wrap
 msgid "Mail links (B<mailto:>)"
 msgstr "Mail-Links (B<mailto:>)"
 
 #. type: Plain text
-#: en/linkchecker.1:339
+#: en/linkchecker.1:345
 msgid ""
 "A mailto: link eventually resolves to a list of email addresses.  If one "
 "address fails, the whole list will fail.  For each mail address we check the "
@@ -1280,133 +1375,175 @@ msgstr ""
 "Mail-Adresse werden die folgenden Dinge geprüft:"
 
 #. type: Plain text
-#: en/linkchecker.1:349
-#, no-wrap
+#: en/linkchecker.1:347
 msgid ""
-"  1) Check the adress syntax, both of the part before and after\n"
-"     the @ sign.\n"
-"  2) Look up the MX DNS records. If we found no MX record,\n"
-"     print an error.\n"
-"  3) Check if one of the mail hosts accept an SMTP connection.\n"
-"     Check hosts with higher priority first.\n"
-"     If no host accepts SMTP, we print a warning.\n"
-"  4) Try to verify the address with the VRFY command. If we got\n"
-"     an answer, print the verified address as an info.\n"
+"1) Check the adress syntax, both of the part before and after the @ sign."
 msgstr ""
-"  1) Prüfe die Syntax der Adresse, sowohl den Teil vor als auch nach dem @-Zeichen.\n"
-"  2) Schlage den MX DNS-Datensatz nach. Falls kein MX Datensatz gefunden wurde, wird ein Fehler ausgegeben.\n"
-"  3) Prüfe, ob einer der Mail-Rechner eine SMTP-Verbindung akzeptiert.\n"
-"     Rechner mit höherer Priorität werden zuerst geprüft.\n"
-"     Fall kein Rechner SMTP-Verbindungen akzeptiert, wird eine Warnung ausgegeben.\n"
-"  4) Versuche, die Adresse mit dem VRFY-Befehl zu verifizieren. Falls eine Antwort kommt, wird die verifizierte Adresse als Information ausgegeben.\n"
+
+#. type: Plain text
+#: en/linkchecker.1:349
+msgid ""
+"2) Look up the MX DNS records. If we found no MX record, print an error."
+msgstr ""
+
+#. type: Plain text
+#: en/linkchecker.1:353
+msgid ""
+"3) Check if one of the mail hosts accept an SMTP connection.  Check hosts "
+"with higher priority first.  If no host accepts SMTP, we print a warning."
+msgstr ""
+
+#. type: Plain text
+#: en/linkchecker.1:356
+msgid ""
+"4) Try to verify the address with the VRFY command. If we got an answer, "
+"print the verified address as an info."
+msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:349
+#: en/linkchecker.1:357
 #, no-wrap
 msgid "FTP links (B<ftp:>)"
 msgstr "FTP-Links (B<ftp:>)"
 
 #. type: Plain text
-#: en/linkchecker.1:353
-#, no-wrap
-msgid "  For FTP links we do:\n"
+#: en/linkchecker.1:360
+#, fuzzy
+#| msgid "  For FTP links we do:\n"
+msgid "For FTP links we do:"
 msgstr "Für FTP-Links wird Folgendes geprüft:\n"
 
 #. type: Plain text
-#: en/linkchecker.1:359
-#, no-wrap
-msgid ""
-"  1) connect to the specified host\n"
-"  2) try to login with the given user and password. The default\n"
-"     user is ``anonymous``, the default password is ``anonymous@``.\n"
-"  3) try to change to the given directory\n"
-"  4) list the file with the NLST command\n"
+#: en/linkchecker.1:362
+msgid "1) connect to the specified host"
 msgstr ""
-"  1) Eine Verbindung zum angegeben Rechner wird aufgebaut\n"
-"  2) Versuche, sich mit dem gegebenen Nutzer und Passwort anzumelden. Der Standardbenutzer ist ``anonymous``, das Standardpasswort ist ``anonymous@``.\n"
-"  3) Versuche, in das angegebene Verzeichnis zu wechseln\n"
-"  4) Liste die Dateien im Verzeichnis auf mit dem NLST-Befehl\n"
-
-#. type: TP
-#: en/linkchecker.1:360
-#, no-wrap
-msgid "Telnet links (``telnet:``)"
-msgstr "Telnet-Links (``telnet:``)"
 
 #. type: Plain text
 #: en/linkchecker.1:365
-#, no-wrap
+#, fuzzy
+#| msgid ""
+#| "  1) connect to the specified host\n"
+#| "  2) try to login with the given user and password. The default\n"
+#| "     user is ``anonymous``, the default password is ``anonymous@``.\n"
+#| "  3) try to change to the given directory\n"
+#| "  4) list the file with the NLST command\n"
 msgid ""
-"  We try to connect and if user/password are given, login to the\n"
-"  given telnet server.\n"
-msgstr "  Versuche, zu dem angegeben Telnetrechner zu verginden und falls Benutzer/Passwort angegeben sind, wird versucht, sich anzumelden.\n"
+"2) try to login with the given user and password. The default user is "
+"B<anonymous>, the default password is B<anonymous@>."
+msgstr ""
+"  1) Eine Verbindung zum angegeben Rechner wird aufgebaut\n"
+"  2) Versuche, sich mit dem gegebenen Nutzer und Passwort anzumelden. Der "
+"Standardbenutzer ist ``anonymous``, das Standardpasswort ist "
+"``anonymous@``.\n"
+"  3) Versuche, in das angegebene Verzeichnis zu wechseln\n"
+"  4) Liste die Dateien im Verzeichnis auf mit dem NLST-Befehl\n"
+
+#. type: Plain text
+#: en/linkchecker.1:367
+msgid "3) try to change to the given directory"
+msgstr ""
+
+#. type: Plain text
+#: en/linkchecker.1:369
+msgid "4) list the file with the NLST command"
+msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:366
-#, no-wrap
-msgid "NNTP links (``news:``, ``snews:``, ``nntp``)"
+#: en/linkchecker.1:370
+#, fuzzy, no-wrap
+#| msgid "Telnet links (``telnet:``)"
+msgid "Telnet links (B<telnet:>)"
+msgstr "Telnet-Links (``telnet:``)"
+
+#. type: Plain text
+#: en/linkchecker.1:374
+#, fuzzy
+#| msgid ""
+#| "  We try to connect and if user/password are given, login to the\n"
+#| "  given telnet server.\n"
+msgid ""
+"We try to connect and if user/password are given, login to the given telnet "
+"server."
+msgstr ""
+"  Versuche, zu dem angegeben Telnetrechner zu verginden und falls Benutzer/"
+"Passwort angegeben sind, wird versucht, sich anzumelden.\n"
+
+#. type: TP
+#: en/linkchecker.1:375
+#, fuzzy, no-wrap
+#| msgid "NNTP links (``news:``, ``snews:``, ``nntp``)"
+msgid "NNTP links (B<news:>, B<snews:>, B<nntp>)"
 msgstr "NNTP-Links (``news:``, ``snews:``, ``nntp``)"
 
 #. type: Plain text
-#: en/linkchecker.1:371
-#, no-wrap
+#: en/linkchecker.1:379
+#, fuzzy
+#| msgid ""
+#| "  We try to connect to the given NNTP server. If a news group or\n"
+#| "  article is specified, try to request it from the server.\n"
 msgid ""
-"  We try to connect to the given NNTP server. If a news group or\n"
-"  article is specified, try to request it from the server.\n"
-msgstr "  Versuche, zu dem angegebenen NNTP-Rechner eine Verbindung aufzubaucne. Falls eine Nachrichtengruppe oder ein bestimmter Artikel angegeben ist, wird versucht, diese Gruppe oder diesen Artikel vom Rechner anzufragen.\n"
+"We try to connect to the given NNTP server. If a news group or article is "
+"specified, try to request it from the server."
+msgstr ""
+"  Versuche, zu dem angegebenen NNTP-Rechner eine Verbindung aufzubaucne. "
+"Falls eine Nachrichtengruppe oder ein bestimmter Artikel angegeben ist, wird "
+"versucht, diese Gruppe oder diesen Artikel vom Rechner anzufragen.\n"
 
 #. type: TP
-#: en/linkchecker.1:372
-#, no-wrap
-msgid "Unsupported links (``javascript:``, etc.)"
+#: en/linkchecker.1:380
+#, fuzzy, no-wrap
+#| msgid "Unsupported links (``javascript:``, etc.)"
+msgid "Unsupported links (B<javascript:>, etc.)"
 msgstr "Nicht unterstützte Links (``javascript:``, etc.)"
 
 #. type: Plain text
-#: en/linkchecker.1:377
-#, no-wrap
+#: en/linkchecker.1:384
+#, fuzzy
+#| msgid ""
+#| "  An unsupported link will only print a warning. No further checking\n"
+#| "  will be made.\n"
 msgid ""
-"  An unsupported link will only print a warning. No further checking\n"
-"  will be made.\n"
-msgstr "  Ein nicht unterstützter Link wird nur eine Warnung ausgeben. Weitere Prüfungen werden nicht durchgeführt.\n"
+"An unsupported link will only print a warning. No further checking will be "
+"made."
+msgstr ""
+"  Ein nicht unterstützter Link wird nur eine Warnung ausgeben. Weitere "
+"Prüfungen werden nicht durchgeführt.\n"
 
 #. type: Plain text
-#: en/linkchecker.1:381
-#, no-wrap
+#: en/linkchecker.1:392
+#, fuzzy
+#| msgid ""
+#| "  The complete list of recognized, but unsupported links can be found\n"
+#| "  in the B<linkcheck/checker/unknownurl.py> source file.\n"
+#| "  The most prominent of them should be JavaScript links.\n"
 msgid ""
-"  The complete list of recognized, but unsupported links can be found\n"
-"  in the B<linkcheck/checker/unknownurl.py> source file.\n"
-"  The most prominent of them should be JavaScript links.\n"
+"The complete list of recognized, but unsupported links can be found in the "
+"E<.UR https://github.com/linkchecker/linkchecker/blob/master/linkcheck/"
+"checker/unknownurl.py> linkcheck/checker/unknownurl.py E<.UE> source file.  "
+"The most prominent of them should be JavaScript links."
 msgstr ""
-"  Die komplette Liste von erkannten, aber nicht unterstützten Links ist in der\n"
-"  Quelldatei B<linkcheck/checker/unknownurl.py>. Die bekanntesten davon dürften JavaScript-Links sein.\n"
+"  Die komplette Liste von erkannten, aber nicht unterstützten Links ist in "
+"der\n"
+"  Quelldatei B<linkcheck/checker/unknownurl.py>. Die bekanntesten davon "
+"dürften JavaScript-Links sein.\n"
 
 #. type: SH
-#: en/linkchecker.1:382 en/linkcheckerrc.5:443
+#: en/linkchecker.1:392 en/linkcheckerrc.5:451
 #, no-wrap
 msgid "PLUGINS"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:384
-msgid "There are two plugin types: connection and content plugins."
-msgstr ""
-
-#. type: Plain text
-#: en/linkchecker.1:387
+#: en/linkchecker.1:399
 msgid ""
-"Connection plugins are run after a successful connection to the URL host."
+"There are two plugin types: connection and content plugins.  Connection "
+"plugins are run after a successful connection to the URL host.  Content "
+"plugins are run if the URL type has content (mailto: URLs have no content "
+"for example) and if the check is not forbidden (ie. by HTTP robots.txt)."
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:391
-msgid ""
-"Content plugins are run if the URL type has content (mailto: URLs have no "
-"content for example) and if the check is not forbidden (ie. by HTTP robots."
-"txt)."
-msgstr ""
-
-#. type: Plain text
-#: en/linkchecker.1:395
+#: en/linkchecker.1:404
 msgid ""
 "See B<linkchecker --list-plugins> for a list of plugins and their "
 "documentation. All plugins are enabled via the B<linkcheckerrc>(5)  "
@@ -1415,13 +1552,13 @@ msgstr ""
 
 # type: SH
 #. type: SH
-#: en/linkchecker.1:396
+#: en/linkchecker.1:405
 #, no-wrap
 msgid "RECURSION"
 msgstr "Rekursion"
 
 #. type: Plain text
-#: en/linkchecker.1:399
+#: en/linkchecker.1:408
 msgid ""
 "Before descending recursively into a URL, it has to fulfill several "
 "conditions. They are checked in this order:"
@@ -1430,12 +1567,12 @@ msgstr ""
 "erfüllen. Diese werden in folgender Reihenfolge geprüft:"
 
 #. type: Plain text
-#: en/linkchecker.1:401
+#: en/linkchecker.1:410
 msgid "1. A URL must be valid."
 msgstr "1. Eine URL muss gültig sein."
 
 #. type: Plain text
-#: en/linkchecker.1:407
+#: en/linkchecker.1:416
 #, no-wrap
 msgid ""
 "2. A URL must be parseable. This currently includes HTML files,\n"
@@ -1446,7 +1583,7 @@ msgid ""
 msgstr "2. Der URL-Inhalt muss analysierbar sein. Dies beinhaltet zur Zeit HTML-Dateien, Opera Lesezeichen, und Verzeichnisse. Falls ein Dateityp nicht erkannt wird, (zum Beispiel weil er keine bekannte HTML-Dateierweiterung besitzt, und der Inhalt nicht nach HTML aussieht), wird der Inhalt als nicht analysierbar angesehen.\n"
 
 #. type: Plain text
-#: en/linkchecker.1:410
+#: en/linkchecker.1:419
 #, no-wrap
 msgid ""
 "3. The URL content must be retrievable. This is usually the case\n"
@@ -1454,7 +1591,7 @@ msgid ""
 msgstr "3. Der URL-Inhalt muss ladbar sein. Dies ist normalerweise der Fall, mit Ausnahme von mailto: oder unbekannten URL-Typen.\n"
 
 #. type: Plain text
-#: en/linkchecker.1:413
+#: en/linkchecker.1:422
 #, no-wrap
 msgid ""
 "4. The maximum recursion level must not be exceeded. It is configured\n"
@@ -1462,7 +1599,7 @@ msgid ""
 msgstr "4. Die maximale Rekursionstiefe darf nicht überschritten werden. Diese wird mit der Option B<--recursion-level> konfiguriert und ist standardmäßig nicht limitiert.\n"
 
 #. type: Plain text
-#: en/linkchecker.1:416
+#: en/linkchecker.1:425
 #, no-wrap
 msgid ""
 "5. It must not match the ignored URL list. This is controlled with\n"
@@ -1470,7 +1607,7 @@ msgid ""
 msgstr "5. Die URL darf nicht in der Liste von ignorierten URLs sein. Die ignorierten URLs werden mit der Option B<--ignore-url> konfiguriert.\n"
 
 #. type: Plain text
-#: en/linkchecker.1:420
+#: en/linkchecker.1:429
 #, no-wrap
 msgid ""
 "6. The Robots Exclusion Protocol must allow links in the URL to be\n"
@@ -1479,7 +1616,7 @@ msgid ""
 msgstr "6. Das Robots Exclusion Protocol muss es erlauben, dass Verknüpfungen in der URL rekursiv verfolgt werden können. Dies wird geprüft, indem in den HTML Kopfdaten nach der \"nofollow\"-Direktive gesucht wird.\n"
 
 #. type: Plain text
-#: en/linkchecker.1:423
+#: en/linkchecker.1:432
 msgid ""
 "Note that the directory recursion reads all files in that directory, not "
 "just a subset like B<index.htm*>."
@@ -1489,14 +1626,14 @@ msgstr ""
 
 # type: SH
 #. type: SH
-#: en/linkchecker.1:424
+#: en/linkchecker.1:433
 #, no-wrap
 msgid "NOTES"
 msgstr "BEMERKUNGEN"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:429
+#: en/linkchecker.1:438
 msgid ""
 "URLs on the commandline starting with B<ftp.> are treated like B<ftp://ftp."
 ">, URLs starting with B<www.> are treated like B<http://www.>.  You can also "
@@ -1508,7 +1645,7 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:434
+#: en/linkchecker.1:443
 msgid ""
 "If you have your system configured to automatically establish a connection "
 "to the internet (e.g. with diald), it will connect when checking links not "
@@ -1521,13 +1658,13 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:436
+#: en/linkchecker.1:445
 msgid "Javascript links are not supported."
 msgstr "Javascript Links werden nicht unterstützt."
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:439
+#: en/linkchecker.1:448
 msgid ""
 "If your platform does not support threading, LinkChecker disables it "
 "automatically."
@@ -1537,7 +1674,7 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:441
+#: en/linkchecker.1:450
 msgid "You can supply multiple user/password pairs in a configuration file."
 msgstr ""
 "Sie können mehrere Benutzer/Passwort Paare in einer Konfigurationsdatei "
@@ -1545,7 +1682,7 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:444
+#: en/linkchecker.1:453
 msgid ""
 "When checking B<news:> links the given NNTP host doesn't need to be the same "
 "as the host of the user browsing your pages."
@@ -1555,31 +1692,31 @@ msgstr ""
 
 # type: SH
 #. type: SH
-#: en/linkchecker.1:445
+#: en/linkchecker.1:454
 #, no-wrap
 msgid "ENVIRONMENT"
 msgstr "UMGEBUNG"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:447
+#: en/linkchecker.1:456
 msgid "B<NNTP_SERVER> - specifies default NNTP server"
 msgstr "B<NNTP_SERVER> - gibt Standard NNTP Server an"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:449
+#: en/linkchecker.1:458
 msgid "B<http_proxy> - specifies default HTTP proxy server"
 msgstr "B<http_proxy> - gibt Standard HTTP Proxy an"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:451
+#: en/linkchecker.1:460
 msgid "B<ftp_proxy> - specifies default FTP proxy server"
 msgstr "B<ftp_proxy> - gibt Standard FTP Proxy an"
 
 #. type: Plain text
-#: en/linkchecker.1:453
+#: en/linkchecker.1:462
 msgid ""
 "B<no_proxy> - comma-separated list of domains to not contact over a proxy "
 "server"
@@ -1589,63 +1726,63 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:455
+#: en/linkchecker.1:464
 msgid "B<LC_MESSAGES>, B<LANG>, B<LANGUAGE> - specify output language"
 msgstr "B<LC_MESSAGES>, B<LANG>, B<LANGUAGE> - gibt Ausgabesprache an"
 
 # type: SH
 #. type: SH
-#: en/linkchecker.1:456
+#: en/linkchecker.1:465
 #, no-wrap
 msgid "RETURN VALUE"
 msgstr "RÜCKGABEWERT"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:458
+#: en/linkchecker.1:467
 msgid "The return value is 2 when"
 msgstr "Der Rückgabewert ist 2 falls"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:460
+#: en/linkchecker.1:469
 msgid "a program error occurred."
 msgstr "ein Programmfehler aufgetreten ist."
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:462
+#: en/linkchecker.1:471
 msgid "The return value is 1 when"
 msgstr "Der Rückgabewert ist 1 falls"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:464
+#: en/linkchecker.1:473
 msgid "invalid links were found or"
 msgstr "ungültige Verknüpfungen gefunden wurden oder"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:466
+#: en/linkchecker.1:475
 msgid "link warnings were found and warnings are enabled"
 msgstr "Warnungen gefunden wurden und Warnungen aktiviert sind"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:468
+#: en/linkchecker.1:477
 msgid "Else the return value is zero."
 msgstr "Sonst ist der Rückgabewert Null."
 
 # type: SH
 #. type: SH
-#: en/linkchecker.1:469
+#: en/linkchecker.1:478
 #, no-wrap
 msgid "LIMITATIONS"
 msgstr "LIMITIERUNGEN"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:473
+#: en/linkchecker.1:482
 msgid ""
 "LinkChecker consumes memory for each queued URL to check. With thousands of "
 "queued URLs the amount of consumed memory can become quite large. This might "
@@ -1658,101 +1795,104 @@ msgstr ""
 
 # type: SH
 #. type: SH
-#: en/linkchecker.1:474
+#: en/linkchecker.1:483
 #, no-wrap
 msgid "FILES"
 msgstr "DATEIEN"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:476
+#: en/linkchecker.1:485
 msgid "B<~/.linkchecker/linkcheckerrc> - default configuration file"
 msgstr "B<~/.linkchecker/linkcheckerrc> - Standardkonfigurationsdatei"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:478
+#: en/linkchecker.1:487
 msgid "B<~/.linkchecker/blacklist> - default blacklist logger output filename"
 msgstr ""
 "B<~/.linkchecker/blacklist> - Standard Dateiname der blacklist Logger Ausgabe"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:480
+#: en/linkchecker.1:489
 msgid "B<linkchecker-out.>I<TYPE> - default logger file output name"
 msgstr "B<linkchecker-out.>I<TYP> - Standard Dateiname der Logausgabe"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:482
+#: en/linkchecker.1:493
+#, fuzzy
+#| msgid ""
+#| "B<http://docs.python.org/library/codecs.html#standard-encodings> - valid "
+#| "output encodings"
 msgid ""
-"B<http://docs.python.org/library/codecs.html#standard-encodings> - valid "
-"output encodings"
+"E<.UR https://docs.python.org/library/codecs.html#standard-encodings> E<.UE> "
+"- valid output encodings"
 msgstr ""
 "B<http://docs.python.org/library/codecs.html#standard-encodings> - gültige "
 "Ausgabe Enkodierungen"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:484
+#: en/linkchecker.1:497
+#, fuzzy
+#| msgid ""
+#| "B<http://docs.python.org/howto/regex.html> - regular expression "
+#| "documentation"
 msgid ""
-"B<http://docs.python.org/howto/regex.html> - regular expression documentation"
+"E<.UR https://docs.python.org/howto/regex.html> E<.UE> - regular expression "
+"documentation"
 msgstr ""
 "B<http://docs.python.org/howto/regex.html> - Dokumentation zu regulären "
 "Ausdrücken"
 
 # type: SH
 #. type: SH
-#: en/linkchecker.1:485 en/linkcheckerrc.5:553
+#: en/linkchecker.1:498 en/linkcheckerrc.5:565
 #, no-wrap
 msgid "SEE ALSO"
 msgstr "SIEHE AUCH"
 
 # type: TH
 #. type: Plain text
-#: en/linkchecker.1:487
+#: en/linkchecker.1:500
 msgid "B<linkcheckerrc>(5)"
 msgstr "B<linkcheckerrc>(5)"
 
 # type: SH
 #. type: SH
-#: en/linkchecker.1:488 en/linkcheckerrc.5:556
+#: en/linkchecker.1:501 en/linkcheckerrc.5:568
 #, no-wrap
 msgid "AUTHOR"
 msgstr "AUTHOR"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:490 en/linkcheckerrc.5:558
+#: en/linkchecker.1:503 en/linkcheckerrc.5:570
 msgid "Bastian Kleineidam E<lt>bastian.kleineidam@web.deE<gt>"
 msgstr "Bastian Kleineidam E<lt>bastian.kleineidam@web.deE<gt>"
 
 # type: SH
 #. type: SH
-#: en/linkchecker.1:491 en/linkcheckerrc.5:559
+#: en/linkchecker.1:504 en/linkcheckerrc.5:571
 #, no-wrap
 msgid "COPYRIGHT"
 msgstr "COPYRIGHT"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkchecker.1:492 en/linkcheckerrc.5:560
+#: en/linkchecker.1:505 en/linkcheckerrc.5:572
 msgid "Copyright \\(co 2000-2014 Bastian Kleineidam"
 msgstr "Copyright \\(co 2000-2014 Bastian Kleineidam"
 
 # type: TH
 #. type: TH
 #: en/linkcheckerrc.5:1
-#, no-wrap
-msgid "linkcheckerrc"
-msgstr "linkcheckerrc"
-
-# type: TH
-#. type: TH
-#: en/linkcheckerrc.5:1
-#, no-wrap
-msgid "2007-11-30"
-msgstr "2007-11-30"
+#, fuzzy, no-wrap
+#| msgid "LINKCHECKER"
+msgid "LINKCHECKERRC"
+msgstr "LINKCHECKER"
 
 # type: Plain text
 #. type: Plain text
@@ -1802,29 +1942,33 @@ msgstr "B<cookiefile=>I<Dateiname>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:17
+#: en/linkcheckerrc.5:18
+#, fuzzy
+#| msgid ""
+#| "Read a file with initial cookie data. The cookie data format is explained "
+#| "in linkchecker(1)."
 msgid ""
 "Read a file with initial cookie data. The cookie data format is explained in "
-"linkchecker(1)."
+"B<linkchecker>(1)."
 msgstr ""
 "Lese eine Datei mit Cookie-Daten. Das Cookie Datenformat wird in "
 "linkchecker(1) erklärt."
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:19
+#: en/linkcheckerrc.5:20
 msgid "Command line option: B<--cookiefile>"
 msgstr "Kommandozeilenoption: B<--cookiefile>"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:19
+#: en/linkcheckerrc.5:20
 #, no-wrap
 msgid "B<localwebroot=>I<STRING>"
 msgstr "B<localwebroot=>I<STRING>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:23
+#: en/linkcheckerrc.5:24
 msgid ""
 "When checking absolute URLs inside local files, the given root directory is "
 "used as base URL."
@@ -1833,7 +1977,7 @@ msgstr ""
 "Wurzelverzeichnis als Basis-URL benutzt."
 
 #. type: Plain text
-#: en/linkcheckerrc.5:27
+#: en/linkcheckerrc.5:28
 msgid ""
 "Note that the given directory must have URL syntax, so it must use a slash "
 "to join directories instead of a backslash.  And the given directory must "
@@ -1846,74 +1990,74 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:29 en/linkcheckerrc.5:77 en/linkcheckerrc.5:85
-#: en/linkcheckerrc.5:93 en/linkcheckerrc.5:111 en/linkcheckerrc.5:117
-#: en/linkcheckerrc.5:228 en/linkcheckerrc.5:245
+#: en/linkcheckerrc.5:30 en/linkcheckerrc.5:78 en/linkcheckerrc.5:86
+#: en/linkcheckerrc.5:94 en/linkcheckerrc.5:112 en/linkcheckerrc.5:118
+#: en/linkcheckerrc.5:230 en/linkcheckerrc.5:248
 msgid "Command line option: none"
 msgstr "Kommandozeilenoption: keine"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:29
+#: en/linkcheckerrc.5:30
 #, no-wrap
 msgid "B<nntpserver=>I<STRING>"
 msgstr "B<nntpserver=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:36
+#: en/linkcheckerrc.5:37
 msgid "Command line option: B<--nntp-server>"
 msgstr "Kommandozeilenoption: B<--nntp-server>"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:36
+#: en/linkcheckerrc.5:37
 #, no-wrap
 msgid "B<recursionlevel=>I<NUMBER>"
 msgstr "B<recursionlevel=>I<NUMBER>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:43
+#: en/linkcheckerrc.5:44
 msgid "Command line option: B<--recursion-level>"
 msgstr "Kommandozeilenoption: B<--recursion-level>"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:43
+#: en/linkcheckerrc.5:44
 #, no-wrap
 msgid "B<threads=>I<NUMBER>"
 msgstr "B<threads=>I<NUMBER>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:49
+#: en/linkcheckerrc.5:50
 msgid "Command line option: B<--threads>"
 msgstr "Kommandozeilenoption: B<--threads>"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:49
+#: en/linkcheckerrc.5:50
 #, no-wrap
 msgid "B<timeout=>I<NUMBER>"
 msgstr "B<timeout=>I<NUMMER>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:55 en/linkcheckerrc.5:62
+#: en/linkcheckerrc.5:56 en/linkcheckerrc.5:63
 msgid "Command line option: B<--timeout>"
 msgstr "Kommandozeilenoption: B<--timeout>"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:55
+#: en/linkcheckerrc.5:56
 #, fuzzy, no-wrap
 #| msgid "B<timeout=>I<NUMBER>"
 msgid "B<aborttimeout=>I<NUMBER>"
 msgstr "B<timeout=>I<NUMMER>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:60
+#: en/linkcheckerrc.5:61
 msgid ""
 "Time to wait for checks to finish after the user aborts the first time (with "
 "Ctrl-C or the abort button).  The default abort timeout is 300 seconds."
@@ -1921,26 +2065,26 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:62
+#: en/linkcheckerrc.5:63
 #, no-wrap
 msgid "B<useragent=>I<STRING>"
 msgstr "B<useragent=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:69
+#: en/linkcheckerrc.5:70
 msgid "Command line option: B<--user-agent>"
 msgstr "Kommandozeilenoption: B<--user-agent>"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:69
+#: en/linkcheckerrc.5:70
 #, no-wrap
 msgid "B<sslverify=>[B<0>|B<1>|I<filename>]"
 msgstr "B<sslverify=>[B<0>|B<1>|I<dateiname>]"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:75
+#: en/linkcheckerrc.5:76
 msgid ""
 "If set to zero disables SSL certificate checking.  If set to one (the "
 "default) enables SSL certificate checking with the provided CA certificate "
@@ -1953,13 +2097,13 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:77
+#: en/linkcheckerrc.5:78
 #, no-wrap
 msgid "B<maxrunseconds=>I<NUMBER>"
 msgstr "B<maxrunseconds=>I<NUMBER>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:81
+#: en/linkcheckerrc.5:82
 msgid ""
 "Stop checking new URLs after the given number of seconds. Same as if the "
 "user stops (by hitting Ctrl-C) after the given number of seconds."
@@ -1969,19 +2113,19 @@ msgstr ""
 "stoppt (durch Drücken von Strg-C)."
 
 #. type: Plain text
-#: en/linkcheckerrc.5:83
+#: en/linkcheckerrc.5:84
 msgid "The default is not to stop until all URLs are checked."
 msgstr "Standard ist nicht zu stoppen bis alle URLs geprüft sind."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:85
+#: en/linkcheckerrc.5:86
 #, no-wrap
 msgid "B<maxnumurls=>I<NUMBER>"
 msgstr "B<maxnumurls=>I<NUMBER>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:89
+#: en/linkcheckerrc.5:90
 msgid ""
 "Maximum number of URLs to check. New URLs will not be queued after the given "
 "number of URLs is checked."
@@ -1990,53 +2134,53 @@ msgstr ""
 "angenommen nachdem die angegebene Anzahl von URLs geprüft wurde."
 
 #. type: Plain text
-#: en/linkcheckerrc.5:91
+#: en/linkcheckerrc.5:92
 msgid "The default is to queue and check all URLs."
 msgstr "Standard ist alle URLs anzunehmen und zu prüfen."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:93
+#: en/linkcheckerrc.5:94
 #, fuzzy, no-wrap
 #| msgid "B<maxrunseconds=>I<NUMBER>"
 msgid "B<maxrequestspersecond=>I<NUMBER>"
 msgstr "B<maxrunseconds=>I<NUMBER>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:96
+#: en/linkcheckerrc.5:97
 msgid "Limit the maximum number of requests per second to one host."
 msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:96
+#: en/linkcheckerrc.5:97
 #, fuzzy, no-wrap
 #| msgid "B<ignorewarnings=>I<NAME>[B<,>I<NAME>...]"
 msgid "B<allowedschemes=>I<NAME>[B<,>I<NAME>...]"
 msgstr "B<ignorewarnings=>I<NAME>[B<,>I<NAME>...]"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:99
+#: en/linkcheckerrc.5:100
 msgid "Allowed URL schemes as comma-separated list."
 msgstr ""
 
 # type: SS
 #. type: SS
-#: en/linkcheckerrc.5:99
+#: en/linkcheckerrc.5:100
 #, no-wrap
 msgid "[filtering]"
 msgstr "[filtering]"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:100
+#: en/linkcheckerrc.5:101
 #, no-wrap
 msgid "B<ignore=>I<REGEX> (MULTILINE)"
 msgstr "B<ignore=>I<REGEX> (MULTILINE)"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:103
+#: en/linkcheckerrc.5:104
 msgid "Only check syntax of URLs matching the given regular expressions."
 msgstr ""
 "Prüfe lediglich die Syntax von URLs, welche dem angegebenen regulären "
@@ -2044,20 +2188,20 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:105
+#: en/linkcheckerrc.5:106
 msgid "Command line option: B<--ignore-url>"
 msgstr "Kommandozeilenoption: B<--ignore-url>"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:105
+#: en/linkcheckerrc.5:106
 #, no-wrap
 msgid "B<ignorewarnings=>I<NAME>[B<,>I<NAME>...]"
 msgstr "B<ignorewarnings=>I<NAME>[B<,>I<NAME>...]"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:109
+#: en/linkcheckerrc.5:110
 #, fuzzy
 #| msgid ""
 #| "Ignore the comma-separated list of warnings. See B<WARNIGS> for the list "
@@ -2071,14 +2215,14 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:111
+#: en/linkcheckerrc.5:112
 #, no-wrap
 msgid "B<internlinks=>I<REGEX>"
 msgstr "B<internlinks=>I<REGEX>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:115
+#: en/linkcheckerrc.5:116
 msgid ""
 "Regular expression to add more URLs recognized as internal links.  Default "
 "is that URLs given on the command line are internal."
@@ -2088,14 +2232,14 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:117
+#: en/linkcheckerrc.5:118
 #, no-wrap
 msgid "B<nofollow=>I<REGEX> (MULTILINE)"
 msgstr "B<nofollow=>I<REGEX> (MULTILINE)"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:121
+#: en/linkcheckerrc.5:122
 msgid ""
 "Check but do not recurse into URLs matching the given regular expressions."
 msgstr ""
@@ -2104,26 +2248,26 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:123
+#: en/linkcheckerrc.5:124
 msgid "Command line option: B<--no-follow-url>"
 msgstr "Kommandozeilenoption: B<--no-follow-url>"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:123
+#: en/linkcheckerrc.5:124
 #, fuzzy, no-wrap
 #| msgid "B<checkhtml=>[B<0>|B<1>]"
 msgid "B<checkextern=>[B<0>|B<1>]"
 msgstr "B<checkhtml=>[B<0>|B<1>]"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:126
+#: en/linkcheckerrc.5:127
 msgid "Check external links. Default is to check internal links only."
 msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:128
+#: en/linkcheckerrc.5:129
 #, fuzzy
 #| msgid "Command line option: B<--check-html>"
 msgid "Command line option: B<--checkextern>"
@@ -2131,21 +2275,21 @@ msgstr "Kommandozeilenoption: B<--check-html>"
 
 # type: SS
 #. type: SS
-#: en/linkcheckerrc.5:128
+#: en/linkcheckerrc.5:129
 #, no-wrap
 msgid "[authentication]"
 msgstr "[authentication]"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:129
+#: en/linkcheckerrc.5:130
 #, no-wrap
 msgid "B<entry=>I<REGEX> I<USER> [I<PASS>] (MULTILINE)"
 msgstr "B<entry=>I<REGEX> I<BENUTZER> [I<PASSWORT>] (MULTILINE)"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:135
+#: en/linkcheckerrc.5:136
 msgid ""
 "Provide different user/password pairs for different link types.  Entries are "
 "a triple (URL regex, username, password)  or a tuple (URL regex, username), "
@@ -2157,7 +2301,7 @@ msgstr ""
 "Benutzername), wobei die Einträge durch Leerzeichen getrennt sind."
 
 #. type: Plain text
-#: en/linkcheckerrc.5:138
+#: en/linkcheckerrc.5:139
 msgid ""
 "The password is optional and if missing it has to be entered at the "
 "commandline."
@@ -2167,7 +2311,7 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:144
+#: en/linkcheckerrc.5:145
 msgid ""
 "If the regular expression matches the checked URL, the given user/password "
 "pair is used for authentication. The commandline options B<-u> and B<-p> "
@@ -2183,19 +2327,19 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:146
+#: en/linkcheckerrc.5:147
 msgid "Command line option: B<-u>, B<-p>"
 msgstr "Kommandozeilenoption: B<-u>, B<-p>"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:146
+#: en/linkcheckerrc.5:147
 #, no-wrap
 msgid "B<loginurl=>I<URL>"
 msgstr "B<loginurl=>I<URL>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:150
+#: en/linkcheckerrc.5:151
 #, fuzzy
 #| msgid ""
 #| "A login URL to be visited before checking. Also needs authentication data "
@@ -2211,37 +2355,37 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:150
+#: en/linkcheckerrc.5:151
 #, no-wrap
 msgid "B<loginuserfield=>I<STRING>"
 msgstr "B<loginuserfield=>I<NAME>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:153
+#: en/linkcheckerrc.5:154
 msgid "The name of the user CGI field. Default name is B<login>."
 msgstr "Der Name für das Benutzer CGI-Feld. Der Standardname ist B<login>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:153
+#: en/linkcheckerrc.5:154
 #, no-wrap
 msgid "B<loginpasswordfield=>I<STRING>"
 msgstr "B<loginpasswordfield=>I<NAME>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:156
+#: en/linkcheckerrc.5:157
 msgid "The name of the password CGI field. Default name is B<password>."
 msgstr "Der Name für das Passwort CGI-Feld. Der Standardname ist B<password>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:156
+#: en/linkcheckerrc.5:157
 #, no-wrap
 msgid "B<loginextrafields=>I<NAME>B<:>I<VALUE> (MULTILINE)"
 msgstr "B<loginextrafields=>I<NAME>B<:>I<WERT> (MULTILINE)"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:160
+#: en/linkcheckerrc.5:161
 msgid ""
 "Optionally any additional CGI name/value pairs. Note that the default values "
 "are submitted automatically."
@@ -2251,21 +2395,21 @@ msgstr ""
 
 # type: SS
 #. type: SS
-#: en/linkcheckerrc.5:160
+#: en/linkcheckerrc.5:161
 #, no-wrap
 msgid "[output]"
 msgstr "[output]"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:161
+#: en/linkcheckerrc.5:162
 #, no-wrap
 msgid "B<debug=>I<STRING>[B<,>I<STRING>...]"
 msgstr "B<debug=>I<STRING>[B<,>I<STRING>...]"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:167
+#: en/linkcheckerrc.5:168
 #, fuzzy
 #| msgid ""
 #| "Print debugging output for the given loggers.  Available loggers are "
@@ -2282,20 +2426,20 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:169
+#: en/linkcheckerrc.5:170
 msgid "Command line option: B<--debug>"
 msgstr "[output]"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:169
+#: en/linkcheckerrc.5:170
 #, no-wrap
 msgid "B<fileoutput=>I<TYPE>[B<,>I<TYPE>...]"
 msgstr "B<fileoutput=>I<TYPE>[B<,>I<TYPE>...]"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:174
+#: en/linkcheckerrc.5:175
 msgid ""
 "Output to a files B<linkchecker-out.>I<TYPE>, B<$HOME/.linkchecker/"
 "blacklist> for B<blacklist> output."
@@ -2305,7 +2449,7 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:180
+#: en/linkcheckerrc.5:181
 msgid ""
 "Valid file output types are B<text>, B<html>, B<sql>, B<csv>, B<gml>, "
 "B<dot>, B<xml>, B<none> or B<blacklist> Default is no file output. The "
@@ -2319,20 +2463,20 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:182
+#: en/linkcheckerrc.5:183
 msgid "Command line option: B<--file-output>"
 msgstr "Kommandozeilenoption: B<--file-output>"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:182
+#: en/linkcheckerrc.5:183
 #, no-wrap
 msgid "B<log=>I<TYPE>[B</>I<ENCODING>]"
 msgstr "B<log=>I<TYPE>[B</>I<ENCODING>]"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:188
+#: en/linkcheckerrc.5:189
 msgid ""
 "Specify output type as B<text>, B<html>, B<sql>, B<csv>, B<gml>, B<dot>, "
 "B<xml>, B<none> or B<blacklist>.  Default type is B<text>. The various "
@@ -2344,32 +2488,20 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:192
-msgid ""
-"The I<ENCODING> specifies the output encoding, the default is that of your "
-"locale. Valid encodings are listed at B<http://docs.python.org/library/"
-"codecs.html#standard-encodings>."
-msgstr ""
-"Das I<ENCODING> gibt die Ausgabekodierung an. Der Standard ist das der "
-"lokalen Spracheinstellung. Gültige Enkodierungen sind aufgelistet unter "
-"B<http://docs.python.org/library/codecs.html#standard-encodings>."
-
-# type: Plain text
-#. type: Plain text
-#: en/linkcheckerrc.5:194
+#: en/linkcheckerrc.5:196
 msgid "Command line option: B<--output>"
 msgstr "Kommandozeilenoption: B<--output>"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:194
+#: en/linkcheckerrc.5:196
 #, no-wrap
 msgid "B<quiet=>[B<0>|B<1>]"
 msgstr "B<quiet=>[B<0>|B<1>]"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:198
+#: en/linkcheckerrc.5:200
 msgid ""
 "If set, operate quiet. An alias for B<log=none>.  This is only useful with "
 "B<fileoutput>."
@@ -2379,39 +2511,39 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:200 en/linkcheckerrc.5:210
+#: en/linkcheckerrc.5:202 en/linkcheckerrc.5:212
 msgid "Command line option: B<--verbose>"
 msgstr "Kommandozeilenoption: B<--verbose>"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:200
+#: en/linkcheckerrc.5:202
 #, no-wrap
 msgid "B<status=>[B<0>|B<1>]"
 msgstr "B<status=>[B<0>|B<1>]"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:203
+#: en/linkcheckerrc.5:205
 msgid "Control printing check status messages. Default is 1."
 msgstr "Kontrolle der Statusmeldungen. Standard ist 1."
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:205
+#: en/linkcheckerrc.5:207
 msgid "Command line option: B<--no-status>"
 msgstr "Kommandozeilenoption: B<--no-status>"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:205
+#: en/linkcheckerrc.5:207
 #, no-wrap
 msgid "B<verbose=>[B<0>|B<1>]"
 msgstr "B<verbose=>[B<0>|B<1>]"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:208
+#: en/linkcheckerrc.5:210
 msgid ""
 "If set log all checked URLs once. Default is to log only errors and warnings."
 msgstr ""
@@ -2420,14 +2552,14 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:210
+#: en/linkcheckerrc.5:212
 #, no-wrap
 msgid "B<warnings=>[B<0>|B<1>]"
 msgstr "B<warnings=>[B<0>|B<1>]"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:213
+#: en/linkcheckerrc.5:215
 msgid "If set log warnings. Default is to log warnings."
 msgstr ""
 "Falls gesetzt, gebe keine Warnungen aus. Standard ist die Ausgabe von "
@@ -2435,30 +2567,30 @@ msgstr ""
 
 # type: TP
 #. type: Plain text
-#: en/linkcheckerrc.5:215
+#: en/linkcheckerrc.5:217
 msgid "Command line option: B<--no-warnings>"
 msgstr "Kommandozeilenoption: B<--no-warnings>"
 
 # type: TP
 #. type: SS
-#: en/linkcheckerrc.5:215
+#: en/linkcheckerrc.5:217
 #, no-wrap
 msgid "[text]"
 msgstr "[text]"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:216 en/linkcheckerrc.5:279 en/linkcheckerrc.5:289
-#: en/linkcheckerrc.5:299 en/linkcheckerrc.5:315 en/linkcheckerrc.5:331
-#: en/linkcheckerrc.5:362 en/linkcheckerrc.5:369 en/linkcheckerrc.5:379
-#: en/linkcheckerrc.5:389
+#: en/linkcheckerrc.5:218 en/linkcheckerrc.5:282 en/linkcheckerrc.5:292
+#: en/linkcheckerrc.5:302 en/linkcheckerrc.5:318 en/linkcheckerrc.5:334
+#: en/linkcheckerrc.5:365 en/linkcheckerrc.5:372 en/linkcheckerrc.5:382
+#: en/linkcheckerrc.5:392
 #, no-wrap
 msgid "B<filename=>I<STRING>"
 msgstr "B<filename=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:220
+#: en/linkcheckerrc.5:222
 msgid ""
 "Specify output filename for text logging. Default filename is B<linkchecker-"
 "out.txt>."
@@ -2468,22 +2600,22 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:222
+#: en/linkcheckerrc.5:224
 msgid "Command line option: B<--file-output=>"
 msgstr "Kommandozeilenoption: B<--file-output=>"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:222 en/linkcheckerrc.5:282 en/linkcheckerrc.5:292
-#: en/linkcheckerrc.5:302 en/linkcheckerrc.5:318 en/linkcheckerrc.5:334
-#: en/linkcheckerrc.5:372 en/linkcheckerrc.5:382 en/linkcheckerrc.5:392
+#: en/linkcheckerrc.5:224 en/linkcheckerrc.5:285 en/linkcheckerrc.5:295
+#: en/linkcheckerrc.5:305 en/linkcheckerrc.5:321 en/linkcheckerrc.5:337
+#: en/linkcheckerrc.5:375 en/linkcheckerrc.5:385 en/linkcheckerrc.5:395
 #, no-wrap
 msgid "B<parts=>I<STRING>"
 msgstr "B<parts=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:226
+#: en/linkcheckerrc.5:228
 msgid ""
 "Comma-separated list of parts that have to be logged.  See B<LOGGER PARTS> "
 "below."
@@ -2493,39 +2625,43 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:228 en/linkcheckerrc.5:285 en/linkcheckerrc.5:295
-#: en/linkcheckerrc.5:305 en/linkcheckerrc.5:321 en/linkcheckerrc.5:337
-#: en/linkcheckerrc.5:365 en/linkcheckerrc.5:375 en/linkcheckerrc.5:385
-#: en/linkcheckerrc.5:395
+#: en/linkcheckerrc.5:230 en/linkcheckerrc.5:288 en/linkcheckerrc.5:298
+#: en/linkcheckerrc.5:308 en/linkcheckerrc.5:324 en/linkcheckerrc.5:340
+#: en/linkcheckerrc.5:368 en/linkcheckerrc.5:378 en/linkcheckerrc.5:388
+#: en/linkcheckerrc.5:398
 #, no-wrap
 msgid "B<encoding=>I<STRING>"
 msgstr "B<encoding=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:232
+#: en/linkcheckerrc.5:235
+#, fuzzy
+#| msgid ""
+#| "Valid encodings are listed in B<http://docs.python.org/library/codecs."
+#| "html#standard-encodings>."
 msgid ""
-"Valid encodings are listed in B<http://docs.python.org/library/codecs."
-"html#standard-encodings>."
+"Valid encodings are listed in E<.UR https://docs.python.org/library/codecs."
+"html#standard-encodings> E<.UE .>"
 msgstr ""
 "Gültige Enkodierungen sind aufgelistet unter B<http://docs.python.org/"
 "library/codecs.html#standard-encodings>."
 
 #. type: Plain text
-#: en/linkcheckerrc.5:234
+#: en/linkcheckerrc.5:237
 msgid "Default encoding is B<iso-8859-15>."
 msgstr "Die Standardenkodierung ist B<iso-8859-15>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:234
+#: en/linkcheckerrc.5:237
 #, no-wrap
 msgid "I<color*>"
 msgstr "I<color*>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:243
+#: en/linkcheckerrc.5:246
 msgid ""
 "Color settings for the various log parts, syntax is I<color> or I<type>B<;"
 ">I<color>. The I<type> can be B<bold>, B<light>, B<blink>, B<invert>.  The "
@@ -2541,144 +2677,144 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:245
+#: en/linkcheckerrc.5:248
 #, no-wrap
 msgid "B<colorparent=>I<STRING>"
 msgstr "B<colorparent=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:248
+#: en/linkcheckerrc.5:251
 msgid "Set parent color. Default is B<white>."
 msgstr "Setze Farbe des Vaters. Standard ist B<white>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:248
+#: en/linkcheckerrc.5:251
 #, no-wrap
 msgid "B<colorurl=>I<STRING>"
 msgstr "B<colorurl=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:251
+#: en/linkcheckerrc.5:254
 msgid "Set URL color. Default is B<default>."
 msgstr "Setze URL Farbe. Standard ist B<default>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:251
+#: en/linkcheckerrc.5:254
 #, no-wrap
 msgid "B<colorname=>I<STRING>"
 msgstr "B<colorname=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:254
+#: en/linkcheckerrc.5:257
 msgid "Set name color. Default is B<default>."
 msgstr "Kommandozeilenoption: B<--file-output=>"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:254
+#: en/linkcheckerrc.5:257
 #, no-wrap
 msgid "B<colorreal=>I<STRING>"
 msgstr "B<colorreal=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:257
+#: en/linkcheckerrc.5:260
 msgid "Set real URL color. Default is B<cyan>."
 msgstr "Setze Farbe für tatsächliche URL. Default ist B<cyan>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:257
+#: en/linkcheckerrc.5:260
 #, no-wrap
 msgid "B<colorbase=>I<STRING>"
 msgstr "B<colorbase=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:260
+#: en/linkcheckerrc.5:263
 msgid "Set base URL color. Default is B<purple>."
 msgstr "Setzt Basisurl Farbe. Standard ist B<purple>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:260
+#: en/linkcheckerrc.5:263
 #, no-wrap
 msgid "B<colorvalid=>I<STRING>"
 msgstr "B<colorvalid=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:263
+#: en/linkcheckerrc.5:266
 msgid "Set valid color. Default is B<bold;green>."
 msgstr "Setze gültige Farbe. Standard ist B<bold;green>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:263
+#: en/linkcheckerrc.5:266
 #, no-wrap
 msgid "B<colorinvalid=>I<STRING>"
 msgstr "B<colorinvalid=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:266
+#: en/linkcheckerrc.5:269
 msgid "Set invalid color. Default is B<bold;red>."
 msgstr "Setze ungültige Farbe. Standard ist B<bold;red>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:266
+#: en/linkcheckerrc.5:269
 #, no-wrap
 msgid "B<colorinfo=>I<STRING>"
 msgstr "B<colorinfo=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:269
+#: en/linkcheckerrc.5:272
 msgid "Set info color. Default is B<default>."
 msgstr "Setzt Informationsfarbe. Standard ist B<default>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:269
+#: en/linkcheckerrc.5:272
 #, no-wrap
 msgid "B<colorwarning=>I<STRING>"
 msgstr "B<colorwarning=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:272
+#: en/linkcheckerrc.5:275
 msgid "Set warning color. Default is B<bold;yellow>."
 msgstr "Setze Warnfarbe. Standard ist B<bold;yellow>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:272
+#: en/linkcheckerrc.5:275
 #, no-wrap
 msgid "B<colordltime=>I<STRING>"
 msgstr "B<colordltime=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:275
+#: en/linkcheckerrc.5:278
 msgid "Set download time color. Default is B<default>."
 msgstr "Setze Downloadzeitfarbe. Standard ist B<default>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:275
+#: en/linkcheckerrc.5:278
 #, no-wrap
 msgid "B<colorreset=>I<STRING>"
 msgstr "B<colorreset=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:278
+#: en/linkcheckerrc.5:281
 #, fuzzy
 #| msgid "Set reset color. Default is B<deault>."
 msgid "Set reset color. Default is B<default>."
@@ -2686,89 +2822,89 @@ msgstr "Setze Reset Farbe. Standard ist B<default>."
 
 # type: SS
 #. type: SS
-#: en/linkcheckerrc.5:278
+#: en/linkcheckerrc.5:281
 #, no-wrap
 msgid "[gml]"
 msgstr "[gml]"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:282 en/linkcheckerrc.5:285 en/linkcheckerrc.5:288
-#: en/linkcheckerrc.5:292 en/linkcheckerrc.5:295 en/linkcheckerrc.5:298
-#: en/linkcheckerrc.5:302 en/linkcheckerrc.5:305 en/linkcheckerrc.5:308
-#: en/linkcheckerrc.5:318 en/linkcheckerrc.5:321 en/linkcheckerrc.5:324
-#: en/linkcheckerrc.5:334 en/linkcheckerrc.5:337 en/linkcheckerrc.5:340
-#: en/linkcheckerrc.5:365 en/linkcheckerrc.5:368 en/linkcheckerrc.5:372
-#: en/linkcheckerrc.5:375 en/linkcheckerrc.5:378 en/linkcheckerrc.5:382
-#: en/linkcheckerrc.5:385 en/linkcheckerrc.5:388 en/linkcheckerrc.5:392
-#: en/linkcheckerrc.5:395 en/linkcheckerrc.5:398
+#: en/linkcheckerrc.5:285 en/linkcheckerrc.5:288 en/linkcheckerrc.5:291
+#: en/linkcheckerrc.5:295 en/linkcheckerrc.5:298 en/linkcheckerrc.5:301
+#: en/linkcheckerrc.5:305 en/linkcheckerrc.5:308 en/linkcheckerrc.5:311
+#: en/linkcheckerrc.5:321 en/linkcheckerrc.5:324 en/linkcheckerrc.5:327
+#: en/linkcheckerrc.5:337 en/linkcheckerrc.5:340 en/linkcheckerrc.5:343
+#: en/linkcheckerrc.5:368 en/linkcheckerrc.5:371 en/linkcheckerrc.5:375
+#: en/linkcheckerrc.5:378 en/linkcheckerrc.5:381 en/linkcheckerrc.5:385
+#: en/linkcheckerrc.5:388 en/linkcheckerrc.5:391 en/linkcheckerrc.5:395
+#: en/linkcheckerrc.5:398 en/linkcheckerrc.5:401
 msgid "See [text] section above."
 msgstr "Siehe [text] Sektion weiter oben."
 
 # type: SS
 #. type: SS
-#: en/linkcheckerrc.5:288
+#: en/linkcheckerrc.5:291
 #, no-wrap
 msgid "[dot]"
 msgstr "[dot]"
 
 # type: SS
 #. type: SS
-#: en/linkcheckerrc.5:298
+#: en/linkcheckerrc.5:301
 #, no-wrap
 msgid "[csv]"
 msgstr "[csv]"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:308 en/linkcheckerrc.5:327
+#: en/linkcheckerrc.5:311 en/linkcheckerrc.5:330
 #, no-wrap
 msgid "B<separator=>I<CHAR>"
 msgstr "B<separator=>I<CHAR>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:311
+#: en/linkcheckerrc.5:314
 msgid "Set CSV separator. Default is a comma (B<,>)."
 msgstr "Das CSV Trennzeichen. Standard ist Komma (B<,>)."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:311
+#: en/linkcheckerrc.5:314
 #, no-wrap
 msgid "B<quotechar=>I<CHAR>"
 msgstr "B<quotechar=>I<CHAR>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:314
+#: en/linkcheckerrc.5:317
 msgid "Set CSV quote character. Default is a double quote (B<\">)."
 msgstr ""
 "Setze CSV Quotezeichen. Standard ist das doppelte Anführungszeichen (B<\">)."
 
 # type: SS
 #. type: SS
-#: en/linkcheckerrc.5:314
+#: en/linkcheckerrc.5:317
 #, no-wrap
 msgid "[sql]"
 msgstr "[sql]"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:324
+#: en/linkcheckerrc.5:327
 #, no-wrap
 msgid "B<dbname=>I<STRING>"
 msgstr "B<dbname=>I<STRING>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:327
+#: en/linkcheckerrc.5:330
 msgid "Set database name to store into. Default is B<linksdb>."
 msgstr "Setze Datenbankname zum Speichern. Standard ist B<linksdb>."
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:330
+#: en/linkcheckerrc.5:333
 #, fuzzy
 #| msgid "Set SQL command separator character. Default is a semicolor (B<;>)."
 msgid "Set SQL command separator character. Default is a semicolon (B<;>)."
@@ -2776,138 +2912,138 @@ msgstr "Setze SQL Kommandotrennzeichen. Standard ist ein Strichpunkt (B<;>)."
 
 # type: TP
 #. type: SS
-#: en/linkcheckerrc.5:330
+#: en/linkcheckerrc.5:333
 #, no-wrap
 msgid "[html]"
 msgstr "[html]"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:340
+#: en/linkcheckerrc.5:343
 #, no-wrap
 msgid "B<colorbackground=>I<COLOR>"
 msgstr "B<colorbackground=>I<COLOR>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:343
+#: en/linkcheckerrc.5:346
 msgid "Set HTML background color. Default is B<#fff7e5>."
 msgstr "Setze Reset Farbe. Standard ist B<default>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:343
+#: en/linkcheckerrc.5:346
 #, no-wrap
 msgid "B<colorurl=>"
 msgstr "B<colorurl=>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:346
+#: en/linkcheckerrc.5:349
 msgid "Set HTML URL color. Default is B<#dcd5cf>."
 msgstr "Setze HTML URL Farbe. Standard ist B<#dcd5cf>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:346
+#: en/linkcheckerrc.5:349
 #, no-wrap
 msgid "B<colorborder=>"
 msgstr "B<colorborder=>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:349
+#: en/linkcheckerrc.5:352
 msgid "Set HTML border color. Default is B<#000000>."
 msgstr "Setze HTML Rahmenfarbe. Standard ist B<#000000>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:349
+#: en/linkcheckerrc.5:352
 #, no-wrap
 msgid "B<colorlink=>"
 msgstr "B<colorlink=>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:352
+#: en/linkcheckerrc.5:355
 msgid "Set HTML link color. Default is B<#191c83>."
 msgstr "Setze HTML Verknüpfungsfarbe. Standard ist B<#191c83>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:352
+#: en/linkcheckerrc.5:355
 #, no-wrap
 msgid "B<colorwarning=>"
 msgstr "B<colorwarning=>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:355
+#: en/linkcheckerrc.5:358
 msgid "Set HTML warning color. Default is B<#e0954e>."
 msgstr "Setze HTML Warnfarbe. Standard ist B<#e0954e>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:355
+#: en/linkcheckerrc.5:358
 #, no-wrap
 msgid "B<colorerror=>"
 msgstr "B<colorerror=>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:358
+#: en/linkcheckerrc.5:361
 msgid "Set HTML error color. Default is B<#db4930>."
 msgstr "Setze HTML Fehlerfarbe. Standard ist B<#db4930>."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:358
+#: en/linkcheckerrc.5:361
 #, no-wrap
 msgid "B<colorok=>"
 msgstr "B<colorok=>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:361
+#: en/linkcheckerrc.5:364
 msgid "Set HTML valid color. Default is B<#3ba557>."
 msgstr "Setze HTML Gültigkeitsfarbe. Standard ist B<#3ba557>."
 
 # type: TP
 #. type: SS
-#: en/linkcheckerrc.5:361
+#: en/linkcheckerrc.5:364
 #, no-wrap
 msgid "[blacklist]"
 msgstr "[blacklist]"
 
 # type: SS
 #. type: SS
-#: en/linkcheckerrc.5:368
+#: en/linkcheckerrc.5:371
 #, no-wrap
 msgid "[xml]"
 msgstr "[xml]"
 
 # type: TP
 #. type: SS
-#: en/linkcheckerrc.5:378
+#: en/linkcheckerrc.5:381
 #, no-wrap
 msgid "[gxml]"
 msgstr "[gxml]"
 
 #. type: SS
-#: en/linkcheckerrc.5:388
+#: en/linkcheckerrc.5:391
 #, no-wrap
 msgid "[sitemap]"
 msgstr "[sitemap]"
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:398
+#: en/linkcheckerrc.5:401
 #, no-wrap
 msgid "B<priority=>I<FLOAT>"
 msgstr "B<priority=>I<NUMMER>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:402
+#: en/linkcheckerrc.5:405
 msgid ""
 "A number between 0.0 and 1.0 determining the priority. The default priority "
 "for the first URL is 1.0, for all child URLs 0.5."
@@ -2916,13 +3052,13 @@ msgstr ""
 "Standardpriorität für die erste URL ist 1.0, für alle Kind-URLs ist sie 0.5."
 
 #. type: TP
-#: en/linkcheckerrc.5:402
+#: en/linkcheckerrc.5:405
 #, no-wrap
 msgid "B<frequency=>[B<always>|B<hourly>|B<daily>|B<weekly>|B<monthly>|B<yearly>|B<never>]"
 msgstr "B<frequency=>[B<always>|B<hourly>|B<daily>|B<weekly>|B<monthly>|B<yearly>|B<never>]"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:405
+#: en/linkcheckerrc.5:408
 #, fuzzy
 #| msgid "The frequence pages are changing with."
 msgid "How frequently pages are changing."
@@ -2930,58 +3066,209 @@ msgstr "Die Häufigkeit mit der Seiten sich ändern."
 
 # type: SH
 #. type: SH
-#: en/linkcheckerrc.5:406
+#: en/linkcheckerrc.5:409
 #, no-wrap
 msgid "LOGGER PARTS"
 msgstr "AUSGABE PARTS"
 
-# type: Plain text
-#. type: Plain text
-#: en/linkcheckerrc.5:422
+#. type: tbl table
+#: en/linkcheckerrc.5:413
 #, no-wrap
-msgid ""
-" B<all>       (for all parts)\n"
-" B<id>        (a unique ID for each logentry)\n"
-" B<realurl>   (the full url link)\n"
-" B<result>    (valid or invalid, with messages)\n"
-" B<extern>    (1 or 0, only in some logger types reported)\n"
-" B<base>      (base href=...)\n"
-" B<name>      (E<lt>a href=...E<gt>nameE<lt>/aE<gt> and E<lt>img alt=\"name\"E<gt>)\n"
-" B<parenturl> (if any)\n"
-" B<info>      (some additional info, e.g. FTP welcome messages)\n"
-" B<warning>   (warnings)\n"
-" B<dltime>    (download time)\n"
-" B<checktime> (check time)\n"
-" B<url>       (the original url name, can be relative)\n"
-" B<intro>     (the blurb at the beginning, \"starting at ...\")\n"
-" B<outro>     (the blurb at the end, \"found x errors ...\")\n"
+msgid "B<all>"
 msgstr ""
-" B<all>       (für alle Teile)\n"
-" B<id>        (eine eindeutige ID für jeden Logeintrag)\n"
-" B<realurl>   (die volle URL Verknüpfung)\n"
-" B<result>    (gültig oder ungültig, mit Nachrichten)\n"
-" B<extern>    (1 oder 0, nur in einigen Ausgabetypen protokolliert)\n"
-" B<base>      (base href=...)\n"
-" B<name>      (E<lt>a href=...E<gt>nameE<lt>/aE<gt> and E<lt>img alt=\"name\"E<gt>)\n"
-" B<parenturl> (falls vorhanden)\n"
-" B<info>      (einige zusätzliche Infos, z.B. FTP Willkommensnachrichten)\n"
-" B<warning>   (Warnungen)\n"
-" B<dltime>    (Downloadzeit)\n"
-" B<checktime> (Prüfzeit)\n"
-" B<url>       (Der Original URL Name, kann relativ sein)\n"
-" B<intro>     (Das Zeug am Anfang, \"Beginne am ...\")\n"
-" B<outro>     (Das Zeug am Ende, \"X Fehler gefunden ...\")\n"
+
+#. type: tbl table
+#: en/linkcheckerrc.5:413
+#, no-wrap
+msgid "(for all parts)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:414
+#, no-wrap
+msgid "B<id>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:414
+#, no-wrap
+msgid "(a unique ID for each logentry)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:415
+#, no-wrap
+msgid "B<realurl>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:415
+#, no-wrap
+msgid "(the full url link)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:416
+#, no-wrap
+msgid "B<result>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:416
+#, no-wrap
+msgid "(valid or invalid, with messages)"
+msgstr ""
+
+# type: TP
+#. type: tbl table
+#: en/linkcheckerrc.5:417
+#, fuzzy, no-wrap
+#| msgid "B<--check-html>"
+msgid "B<extern>"
+msgstr "B<--check-html>"
+
+#. type: tbl table
+#: en/linkcheckerrc.5:417
+#, no-wrap
+msgid "(1 or 0, only in some logger types reported)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:418
+#, no-wrap
+msgid "B<base>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:418
+#, no-wrap
+msgid "(base href=...)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:419
+#, no-wrap
+msgid "B<name>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:419
+#, no-wrap
+msgid "(E<lt>a href=...E<gt>nameE<lt>/aE<gt> and E<lt>img alt=\"name\"E<gt>)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:420
+#, no-wrap
+msgid "B<parenturl>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:420
+#, no-wrap
+msgid "(if any)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:421
+#, no-wrap
+msgid "B<info>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:421
+#, no-wrap
+msgid "(some additional info, e.g. FTP welcome messages)"
+msgstr ""
+
+# type: TP
+#. type: tbl table
+#: en/linkcheckerrc.5:422
+#, fuzzy, no-wrap
+#| msgid "B<--no-warnings>"
+msgid "B<warning>"
+msgstr "B<--no-warnings>"
+
+# type: TP
+#. type: tbl table
+#: en/linkcheckerrc.5:422
+#, fuzzy, no-wrap
+#| msgid "B<--no-warnings>"
+msgid "(warnings)"
+msgstr "B<--no-warnings>"
+
+#. type: tbl table
+#: en/linkcheckerrc.5:423
+#, no-wrap
+msgid "B<dltime>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:423
+#, no-wrap
+msgid "(download time)"
+msgstr ""
+
+# type: TP
+#. type: tbl table
+#: en/linkcheckerrc.5:424
+#, fuzzy, no-wrap
+#| msgid "B<--check-html>"
+msgid "B<checktime>"
+msgstr "B<--check-html>"
+
+#. type: tbl table
+#: en/linkcheckerrc.5:424
+#, no-wrap
+msgid "(check time)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:425
+#, no-wrap
+msgid "B<url>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:425
+#, no-wrap
+msgid "(the original url name, can be relative)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:426
+#, no-wrap
+msgid "B<intro>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:426
+#, no-wrap
+msgid "(the blurb at the beginning, \"starting at ...\")"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:427
+#, no-wrap
+msgid "B<outro>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:427
+#, no-wrap
+msgid "(the blurb at the end, \"found x errors ...\")"
+msgstr ""
 
 # type: SH
 #. type: SH
-#: en/linkcheckerrc.5:422
+#: en/linkcheckerrc.5:429
 #, no-wrap
 msgid "MULTILINE"
 msgstr "MULTILINE"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:426
+#: en/linkcheckerrc.5:433
 msgid ""
 "Some option values can span multiple lines. Each line has to be indented for "
 "that to work. Lines starting with a hash (B<#>) will be ignored, though they "
@@ -2993,14 +3280,20 @@ msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:432
-#, no-wrap
+#: en/linkcheckerrc.5:439
+#, fuzzy, no-wrap
+#| msgid ""
+#| " ignore=\n"
+#| "   lconline\n"
+#| "   bookmark\n"
+#| "   # a comment\n"
+#| "   ^mailto:\n"
 msgid ""
-" ignore=\n"
-"   lconline\n"
-"   bookmark\n"
-"   # a comment\n"
-"   ^mailto:\n"
+"ignore=\n"
+"  lconline\n"
+"  bookmark\n"
+"  # a comment\n"
+"  ^mailto:\n"
 msgstr ""
 " ignore=\n"
 "   lconline\n"
@@ -3009,46 +3302,55 @@ msgstr ""
 
 # type: SH
 #. type: SH
-#: en/linkcheckerrc.5:433
+#: en/linkcheckerrc.5:440
 #, no-wrap
 msgid "EXAMPLE"
 msgstr "BEISPIEL"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:436
-#, no-wrap
+#: en/linkcheckerrc.5:444
+#, fuzzy, no-wrap
+#| msgid ""
+#| " [output]\n"
+#| " log=html\n"
 msgid ""
-" [output]\n"
-" log=html\n"
+"[output]\n"
+"log=html\n"
 msgstr ""
 " [output]\n"
 " log=html\n"
 
 # type: Plain text
-#. type: Plain text
-#: en/linkcheckerrc.5:439
-#, no-wrap
-msgid ""
-" [checking]\n"
-" threads=5\n"
-msgstr ""
-" [checking]\n"
-" threads=5\n"
-
-# type: Plain text
-#. type: Plain text
-#: en/linkcheckerrc.5:442
-#, no-wrap
-msgid ""
-" [filtering]\n"
-" ignorewarnings=http-moved-permanent\n"
-msgstr ""
-" [filtering]\n"
-" ignorewarnings=http-moved-permanent\n"
-
 #. type: Plain text
 #: en/linkcheckerrc.5:447
+#, fuzzy, no-wrap
+#| msgid ""
+#| " [checking]\n"
+#| " threads=5\n"
+msgid ""
+"[checking]\n"
+"threads=5\n"
+msgstr ""
+" [checking]\n"
+" threads=5\n"
+
+# type: Plain text
+#. type: Plain text
+#: en/linkcheckerrc.5:450
+#, fuzzy, no-wrap
+#| msgid ""
+#| " [filtering]\n"
+#| " ignorewarnings=http-moved-permanent\n"
+msgid ""
+"[filtering]\n"
+"ignorewarnings=http-moved-permanent\n"
+msgstr ""
+" [filtering]\n"
+" ignorewarnings=http-moved-permanent\n"
+
+#. type: Plain text
+#: en/linkcheckerrc.5:455
 msgid ""
 "All plugins have a separate section. If the section appears in the "
 "configuration file the plugin is enabled.  Some plugins read extra options "
@@ -3057,39 +3359,39 @@ msgstr ""
 
 # type: SS
 #. type: SS
-#: en/linkcheckerrc.5:448
+#: en/linkcheckerrc.5:456
 #, fuzzy, no-wrap
 #| msgid "[checking]"
 msgid "[AnchorCheck]"
 msgstr "[checking]"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:450
+#: en/linkcheckerrc.5:458
 msgid "Checks validity of HTML anchors."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:451
+#: en/linkcheckerrc.5:459
 #, no-wrap
 msgid "[LocationInfo]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:454
+#: en/linkcheckerrc.5:462
 msgid ""
 "Adds the country and if possible city name of the URL host as info.  Needs "
 "GeoIP or pygeoip and a local country or city lookup DB installed."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:455
+#: en/linkcheckerrc.5:463
 #, no-wrap
 msgid "[RegexCheck]"
 msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:459
+#: en/linkcheckerrc.5:467
 #, fuzzy
 #| msgid ""
 #| "Define a regular expression which prints a warning if it matches any "
@@ -3106,7 +3408,7 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:459
+#: en/linkcheckerrc.5:467
 #, fuzzy, no-wrap
 #| msgid "B<-W>I<REGEX>, B<--warning-regex=>I<REGEX>"
 msgid "B<warningregex=>I<REGEX>"
@@ -3114,7 +3416,7 @@ msgstr "B<-W>I<REGEX>, B<--warning-regex=>I<REGEX>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:464
+#: en/linkcheckerrc.5:472
 #, fuzzy
 #| msgid ""
 #| "Use this to check for pages that contain some form of error, for example "
@@ -3129,13 +3431,13 @@ msgstr ""
 "Applikationsfehler\"."
 
 #. type: SS
-#: en/linkcheckerrc.5:468
+#: en/linkcheckerrc.5:476
 #, no-wrap
 msgid "[SslCertificateCheck]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:472
+#: en/linkcheckerrc.5:480
 msgid ""
 "Check SSL certificate expiration date. Only internal https: links will be "
 "checked. A domain will only be checked once to avoid duplicate warnings."
@@ -3143,78 +3445,81 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:472
+#: en/linkcheckerrc.5:480
 #, fuzzy, no-wrap
 #| msgid "B<warnsslcertdaysvalid=>I<NUMBER>"
 msgid "B<sslcertwarndays=>I<NUMBER>"
 msgstr "B<warnsslcertdaysvalid=>I<NUMBER>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:475
+#: en/linkcheckerrc.5:483
 msgid "Configures the expiration warning time in days."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:476
+#: en/linkcheckerrc.5:484
 #, no-wrap
 msgid "[HtmlSyntaxCheck]"
 msgstr ""
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:479
+#: en/linkcheckerrc.5:489
 #, fuzzy
 #| msgid "Check syntax of HTML URLs with the W3C online validator."
 msgid ""
-"Check the syntax of HTML pages with the online W3C HTML validator.  See "
-"http://validator.w3.org/docs/api.html."
+"Check the syntax of HTML pages with the online W3C HTML validator.  See E<."
+"UR https://validator.w3.org/docs/api.html> E<.UE .>"
 msgstr "Prüfe Syntax von HTML URLs mit dem W3C Online Validator."
 
 #. type: SS
-#: en/linkcheckerrc.5:480
+#: en/linkcheckerrc.5:490
 #, no-wrap
 msgid "[HttpHeaderInfo]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:482
+#: en/linkcheckerrc.5:492
 msgid "Print HTTP headers in URL info."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:482
+#: en/linkcheckerrc.5:492
 #, no-wrap
 msgid "B<prefixes=>I<prefix1>[,I<prefix2>]..."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:486
+#: en/linkcheckerrc.5:496
 msgid ""
 "List of comma separated header prefixes. For example to display all HTTP "
 "headers that start with \"X-\"."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:487
+#: en/linkcheckerrc.5:497
 #, no-wrap
 msgid "[CssSyntaxCheck]"
 msgstr ""
 
+# type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:490
+#: en/linkcheckerrc.5:502
+#, fuzzy
+#| msgid "Check syntax of HTML URLs with the W3C online validator."
 msgid ""
-"Check the syntax of HTML pages with the online W3C CSS validator.  See "
-"http://jigsaw.w3.org/css-validator/manual.html#expert."
-msgstr ""
+"Check the syntax of HTML pages with the online W3C CSS validator.  See E<.UR "
+"https://jigsaw.w3.org/css-validator/manual.html#expert> E<.UE .>"
+msgstr "Prüfe Syntax von HTML URLs mit dem W3C Online Validator."
 
 #. type: SS
-#: en/linkcheckerrc.5:491
+#: en/linkcheckerrc.5:503
 #, no-wrap
 msgid "[VirusCheck]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:494
+#: en/linkcheckerrc.5:506
 msgid ""
 "Checks the page content for virus infections with clamav.  A local clamav "
 "daemon must be installed."
@@ -3222,51 +3527,51 @@ msgstr ""
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:494
+#: en/linkcheckerrc.5:506
 #, no-wrap
 msgid "B<clamavconf=>I<filename>"
 msgstr "B<clamavconf=>I<Dateiname>"
 
 # type: Plain text
 #. type: Plain text
-#: en/linkcheckerrc.5:497
+#: en/linkcheckerrc.5:509
 msgid "Filename of B<clamd.conf> config file."
 msgstr "Dateiname von B<clamd.conf> Konfigurationsdatei."
 
 #. type: SS
-#: en/linkcheckerrc.5:498
+#: en/linkcheckerrc.5:510
 #, no-wrap
 msgid "[PdfParser]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:501
+#: en/linkcheckerrc.5:513
 msgid ""
 "Parse PDF files for URLs to check. Needs the B<pdfminer> Python package "
 "installed."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:502
+#: en/linkcheckerrc.5:514
 #, no-wrap
 msgid "[WordParser]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:505
+#: en/linkcheckerrc.5:517
 msgid ""
 "Parse Word files for URLs to check. Needs the B<pywin32> Python extension "
 "installed."
 msgstr ""
 
 #. type: SH
-#: en/linkcheckerrc.5:506
+#: en/linkcheckerrc.5:518
 #, no-wrap
 msgid "WARNINGS"
 msgstr "WARNUNGEN"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:509
+#: en/linkcheckerrc.5:521
 msgid ""
 "The following warnings are recognized in the 'ignorewarnings' config file "
 "entry:"
@@ -3275,163 +3580,184 @@ msgstr ""
 "erkannt:"
 
 #. type: TP
-#: en/linkcheckerrc.5:510
+#: en/linkcheckerrc.5:522
 #, no-wrap
 msgid "B<file-missing-slash>"
 msgstr "B<file-missing-slash>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:513
+#: en/linkcheckerrc.5:525
 msgid "The file: URL is missing a trailing slash."
 msgstr "Der file: URL fehlt ein abschließender Schrägstrich."
 
 #. type: TP
-#: en/linkcheckerrc.5:513
+#: en/linkcheckerrc.5:525
 #, no-wrap
 msgid "B<file-system-path>"
 msgstr "B<file-system-path>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:516
+#: en/linkcheckerrc.5:528
 msgid "The file: path is not the same as the system specific path."
 msgstr "Der file: Pfad ist nicht derselbe wie der Systempfad."
 
 #. type: TP
-#: en/linkcheckerrc.5:516
+#: en/linkcheckerrc.5:528
 #, no-wrap
 msgid "B<ftp-missing-slash>"
 msgstr "B<ftp-missing-slash>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:519
+#: en/linkcheckerrc.5:531
 msgid "The ftp: URL is missing a trailing slash."
 msgstr "Der ftp: URL fehlt ein abschließender Schrägstrich."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:519
+#: en/linkcheckerrc.5:531
 #, no-wrap
 msgid "B<http-cookie-store-error>"
 msgstr "B<http-cookie-store-error>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:522
+#: en/linkcheckerrc.5:534
 msgid "An error occurred while storing a cookie."
 msgstr "Ein Fehler trat auf während des Speicherns eines Cookies."
 
 #. type: TP
-#: en/linkcheckerrc.5:522
+#: en/linkcheckerrc.5:534
 #, no-wrap
 msgid "B<http-empty-content>"
 msgstr "B<http-empty-content>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:525
+#: en/linkcheckerrc.5:537
 msgid "The URL had no content."
 msgstr "Die URL besitzt keinen Inhalt."
 
 #. type: TP
-#: en/linkcheckerrc.5:525
+#: en/linkcheckerrc.5:537
 #, no-wrap
 msgid "B<mail-no-mx-host>"
 msgstr "B<mail-no-mx-host>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:528
+#: en/linkcheckerrc.5:540
 msgid "The mail MX host could not be found."
 msgstr "Der MX Mail-Rechner konnte nicht gefunden werden."
 
 #. type: TP
-#: en/linkcheckerrc.5:528
+#: en/linkcheckerrc.5:540
 #, no-wrap
 msgid "B<nntp-no-newsgroup>"
 msgstr "B<nntp-no-newsgroup>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:531
+#: en/linkcheckerrc.5:543
 msgid "The NNTP newsgroup could not be found."
 msgstr "Die NNTP Nachrichtengruppe konnte nicht gefunden werden."
 
 # type: TP
 #. type: TP
-#: en/linkcheckerrc.5:531
+#: en/linkcheckerrc.5:543
 #, no-wrap
 msgid "B<nntp-no-server>"
 msgstr "B<nntp-no-server>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:534
+#: en/linkcheckerrc.5:546
 msgid "No NNTP server was found."
 msgstr "Es wurde kein NNTP Server gefunden."
 
 #. type: TP
-#: en/linkcheckerrc.5:534
+#: en/linkcheckerrc.5:546
 #, no-wrap
 msgid "B<url-content-size-zero>"
 msgstr "B<url-content-size-zero>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:537
+#: en/linkcheckerrc.5:549
 msgid "The URL content size is zero."
 msgstr "Der URL Inhaltsgrößenangabe ist Null."
 
 #. type: TP
-#: en/linkcheckerrc.5:537
+#: en/linkcheckerrc.5:549
 #, no-wrap
 msgid "B<url-content-too-large>"
 msgstr "B<url-content-too-large>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:540
+#: en/linkcheckerrc.5:552
 msgid "The URL content size is too large."
 msgstr "Der URL Inhalt ist zu groß."
 
 #. type: TP
-#: en/linkcheckerrc.5:540
+#: en/linkcheckerrc.5:552
 #, no-wrap
 msgid "B<url-effective-url>"
 msgstr "B<url-effective-url>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:543
+#: en/linkcheckerrc.5:555
 msgid "The effective URL is different from the original."
 msgstr "Die effektive URL unterscheidet sich vom Original."
 
 #. type: TP
-#: en/linkcheckerrc.5:543
+#: en/linkcheckerrc.5:555
 #, no-wrap
 msgid "B<url-error-getting-content>"
 msgstr "B<url-error-getting-content>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:546
+#: en/linkcheckerrc.5:558
 msgid "Could not get the content of the URL."
 msgstr "Konnte den Inhalt der URL nicht bekommen."
 
 #. type: TP
-#: en/linkcheckerrc.5:546
+#: en/linkcheckerrc.5:558
 #, no-wrap
 msgid "B<url-obfuscated-ip>"
 msgstr "B<url-obfuscated-ip>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:549
+#: en/linkcheckerrc.5:561
 msgid "The IP is obfuscated."
 msgstr "Die IP-Adresse ist verschleiert."
 
 #. type: TP
-#: en/linkcheckerrc.5:549
+#: en/linkcheckerrc.5:561
 #, no-wrap
 msgid "B<url-whitespace>"
 msgstr "B<url-whitespace>"
 
 #. type: Plain text
-#: en/linkcheckerrc.5:552
+#: en/linkcheckerrc.5:564
 msgid "The URL contains leading or trailing whitespace."
 msgstr "Die URL %(url)s enthält Leerzeichen am Anfang oder Ende."
 
 # type: TH
 #. type: Plain text
-#: en/linkcheckerrc.5:555
-msgid "linkchecker(1)"
+#: en/linkcheckerrc.5:567
+#, fuzzy
+#| msgid "linkchecker(1)"
+msgid "B<linkchecker>(1)"
 msgstr "BEISPIEL"
+
+#, no-wrap
+#~ msgid "2010-07-01"
+#~ msgstr "2010-07-01"
+
+# type: TH
+#, no-wrap
+#~ msgid "LinkChecker commandline usage"
+#~ msgstr "LinkChecker auf der Kommandozeile"
+
+# type: Plain text
+#~ msgid ""
+#~ "The I<ENCODING> specifies the output encoding, the default is that of "
+#~ "your locale. Valid encodings are listed at B<http://docs.python.org/"
+#~ "library/\\:codecs.html#standard-encodings>."
+#~ msgstr ""
+#~ "Das I<ENCODING> gibt die Ausgabekodierung an. Der Standard ist das der "
+#~ "lokalen Spracheinstellung. Gültige Enkodierungen sind aufgelistet unter "
+#~ "B<http://docs.python.org/library/\\:codecs.html#standard-encodings>."

--- a/doc/de.po
+++ b/doc/de.po
@@ -1,18 +1,21 @@
 # SOME DESCRIPTIVE TITLE
 # Copyright (C) 2011 Free Software Foundation, Inc.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Bastian Kleineidam <calvin@users.sourceforge.net>, 2005.
+# Chris Mayo <aklhfex@gmail.com>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: linkchecker 3.4\n"
 "POT-Creation-Date: 2020-06-04 17:30+0100\n"
-"PO-Revision-Date: 2013-12-12 21:51+0100\n"
-"Last-Translator: Bastian Kleineidam <calvin@users.sourceforge.net>\n"
-"Language-Team: de <de@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2020-06-04 17:33+0100\n"
+"Last-Translator: Chris Mayo <aklhfex@gmail.com>\n"
+"Language-Team: German - Germany <>\n"
+"Language: de_DE\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Gtranslator 3.36.0\n"
 
 # type: TH
 #. type: TH
@@ -25,7 +28,7 @@ msgstr "LINKCHECKER"
 #: en/linkchecker.1:1 en/linkcheckerrc.5:1
 #, no-wrap
 msgid "2020-04-24"
-msgstr ""
+msgstr "2020-04-24"
 
 # type: TH
 #. type: TH
@@ -181,15 +184,12 @@ msgstr "BEISPIELE"
 #| "URL pointing outside of the domain:\n"
 #| "  B<linkchecker http://www.example.net/>\n"
 msgid "The most common use checks the given domain recursively:"
-msgstr ""
-"Der häufigste Gebrauchsfall prüft die angegebene Domäne rekursiv,\n"
-"inklusive aller einzelnen nach außen zeigenden Verknüpfungen:\n"
-"  B<linkchecker http://www.example.net/>\n"
+msgstr "Der häufigste Gebrauchsfall prüft die angegebene Domäne rekursiv, inklusive aller einzelnen nach außen zeigenden Verknüpfungen:"
 
 #. type: Plain text
 #: en/linkchecker.1:39
 msgid "B<linkchecker http://www.example.com/>"
-msgstr ""
+msgstr "B<linkchecker http://www.example.com/>"
 
 # type: Plain text
 #. type: Plain text
@@ -210,116 +210,76 @@ msgstr ""
 #| "Don't check B<mailto:> URLs. All other links are checked as usual:\n"
 #| "  B<linkchecker --ignore-url=^mailto: mysite.example.org>\n"
 msgid "Don't check URLs with B</secret> in its name. All other links are checked as usual:"
-msgstr ""
-"Prüfe keine B<mailto:> URLs. Alle anderen Verknüpfungen werden wie üblich geprüft:\n"
-"  B<linkchecker --ignore-url=^mailto: mysite.example.org>\n"
+msgstr "Prüfe keine B<mailto:> URLs. Alle anderen Verknüpfungen werden wie üblich geprüft:\n"
 
 #. type: Plain text
 #: en/linkchecker.1:45
 msgid "B<linkchecker --ignore-url=/secret mysite.example.com>"
-msgstr ""
+msgstr "B<linkchecker --ignore-url=/secret mysite.example.com>"
 
 # type: Plain text
 #. type: TP
 #: en/linkchecker.1:45
-#, fuzzy, no-wrap
-#| msgid ""
-#| "Checking a local HTML file on Unix:\n"
-#| "  B<linkchecker ../bla.html>\n"
+#, no-wrap
 msgid "Checking a local HTML file on Unix:"
-msgstr ""
-"Überprüfung einer lokalen HTML Datei unter Unix:\n"
-"  B<linkchecker ../bla.html>\n"
+msgstr "Überprüfung einer lokalen HTML Datei unter Unix:"
 
 # type: TH
 #. type: Plain text
 #: en/linkchecker.1:48
-#, fuzzy
-#| msgid "B<linkcheckerrc>(5)"
 msgid "B<linkchecker ../bla.html>"
-msgstr "B<linkcheckerrc>(5)"
+msgstr "B<linkchecker ../bla.html>"
 
 # type: Plain text
 #. type: TP
 #: en/linkchecker.1:48
-#, fuzzy, no-wrap
-#| msgid ""
-#| "Checking a local HTML file on Windows:\n"
-#| "  B<linkchecker c:\\etemp\\etest.html>\n"
+#, no-wrap
 msgid "Checking a local HTML file on Windows:"
-msgstr ""
-"Überprüfung einer lokalen HTML Datei unter Windows:\n"
-"  B<linkchecker c:\\etemp\\etest.html>\n"
+msgstr "Überprüfung einer lokalen HTML Datei unter Windows:"
 
 #. type: Plain text
 #: en/linkchecker.1:51
 msgid "B<linkchecker c:\\temp\\test.html>"
-msgstr ""
+msgstr "B<linkchecker c:\\temp\\test.html>"
 
 # type: Plain text
 #. type: TP
 #: en/linkchecker.1:51
-#, fuzzy, no-wrap
-#| msgid ""
-#| "You can skip the B<http://> url part if the domain starts with B<www.>:\n"
-#| "  B<linkchecker www.example.com>\n"
+#, no-wrap
 msgid "You can skip the B<http://> url part if the domain starts with B<www.>:"
-msgstr ""
-"Sie können den B<http://> URL Anteil weglassen wenn die Domäne mit B<www.> beginnt:\n"
-"  B<linkchecker www.example.com>\n"
+msgstr "Sie können den B<http://> URL Anteil weglassen wenn die Domäne mit B<www.> beginnt:"
 
 # type: TH
 #. type: Plain text
 #: en/linkchecker.1:54
-#, fuzzy
-#| msgid "B<linkcheckerrc>(5)"
 msgid "B<linkchecker www.example.com>"
-msgstr "B<linkcheckerrc>(5)"
+msgstr "B<linkchecker www.example.com>"
 
 # type: Plain text
 #. type: TP
 #: en/linkchecker.1:54
-#, fuzzy, no-wrap
-#| msgid ""
-#| "You can skip the B<ftp://> url part if the domain starts with B<ftp.>:\n"
-#| "  B<linkchecker -r0 ftp.example.org>\n"
+#, no-wrap
 msgid "You can skip the B<ftp://> url part if the domain starts with B<ftp.>:"
-msgstr ""
-"Sie können den B<ftp://> URL Anteil weglassen wenn die Domäne mit B<ftp.> beginnt:\n"
-"  B<linkchecker -r0 ftp.example.org>\n"
+msgstr "Sie können den B<ftp://> URL Anteil weglassen wenn die Domäne mit B<ftp.>"
 
 # type: TH
 #. type: Plain text
 #: en/linkchecker.1:57
-#, fuzzy
-#| msgid "B<linkcheckerrc>(5)"
 msgid "B<linkchecker -r0 ftp.example.com>"
-msgstr "B<linkcheckerrc>(5)"
+msgstr "B<linkchecker -r0 ftp.example.com>"
 
 # type: Plain text
 #. type: TP
 #: en/linkchecker.1:57
-#, fuzzy, no-wrap
-#| msgid ""
-#| "Generate a sitemap graph and convert it with the graphviz dot utility:\n"
-#| "  B<linkchecker -odot -v www.example.com | dot -Tps E<gt> sitemap.ps>\n"
+#, no-wrap
 msgid "Generate a sitemap graph and convert it with the graphviz dot utility:"
-msgstr ""
-"Erzeuge einen Sitemap Graphen und konvertiere ihn mit dem graphviz dot Programm:\n"
-"  B<linkchecker -odot -v www.example.com | dot -Tps E<gt> sitemap.ps>\n"
+msgstr "Erzeuge einen Sitemap Graphen und konvertiere ihn mit dem graphviz dot Programm:"
 
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:60
-#, fuzzy
-#| msgid ""
-#| "Generate a sitemap graph and convert it with the graphviz dot utility:\n"
-#| "  B<linkchecker -odot -v www.example.com | dot -Tps E<gt> sitemap.ps>\n"
 msgid "B<linkchecker -odot -v www.example.com | dot -Tps E<gt> sitemap.ps>"
-msgstr ""
-"Erzeuge einen Sitemap Graphen und konvertiere ihn mit dem graphviz dot "
-"Programm:\n"
-"  B<linkchecker -odot -v www.example.com | dot -Tps E<gt> sitemap.ps>\n"
+msgstr "B<linkchecker -odot -v www.example.com | dot -Tps E<gt> sitemap.ps>"
 
 # type: SH
 #. type: SH
@@ -390,10 +350,6 @@ msgstr "B<-t>I<NUMMER>, B<--threads=>I<NUMMER>"
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:76 en/linkcheckerrc.5:48
-#, fuzzy
-#| msgid ""
-#| "Generate no more than the given number of threads. Default number of "
-#| "threads is 10. To disable threading specify a non-positive number."
 msgid ""
 "Generate no more than the given number of threads. Default number of threads "
 "is 10. To disable threading specify a non-positive number."
@@ -418,10 +374,9 @@ msgstr "Gebe die Version aus und beende das Programm."
 # type: TP
 #. type: TP
 #: en/linkchecker.1:79
-#, fuzzy, no-wrap
-#| msgid "B<--stdin>"
+#, no-wrap
 msgid "B<--list-plugins>"
-msgstr "B<--stdin>"
+msgstr "B<--list-plugins>"
 
 # type: Plain text
 #. type: Plain text
@@ -448,13 +403,6 @@ msgstr "B<-D>I<NAME>, B<--debug=>I<NAME>"
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:94
-#, fuzzy
-#| msgid ""
-#| "Print debugging output for the given logger.  Available loggers are "
-#| "B<cmdline>, B<checking>, B<cache>, B<dns>, B<plugins> and B<all>.  "
-#| "Specifying B<all> is an alias for specifying all available loggers.  The "
-#| "option can be given multiple times to debug with more than one logger.  "
-#| "For accurate results, threading will be disabled during debug runs."
 msgid ""
 "Print debugging output for the given logger.  Available loggers are "
 "B<cmdline>, B<checking>, B<cache>, B<dns>, B<plugin> and B<all>.  Specifying "
@@ -478,13 +426,6 @@ msgstr "B<-F>I<TYP>[B</>I<ENKODIERUNG>][B</>I<DATEINAME>], B<--file-output=>I<TY
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:104
-#, fuzzy
-#| msgid ""
-#| "Output to a file B<linkchecker-out.>I<TYPE>, B<$HOME/.linkchecker/"
-#| "blacklist> for B<blacklist> output, or I<FILENAME> if specified.  The "
-#| "I<ENCODING> specifies the output encoding, the default is that of your "
-#| "locale.  Valid encodings are listed at B<http://docs.python.org/library/"
-#| "\\:codecs.html#standard-encodings>."
 msgid ""
 "Output to a file B<linkchecker-out.>I<TYPE>, B<$HOME/.linkchecker/blacklist> "
 "for B<blacklist> output, or I<FILENAME> if specified.  The I<ENCODING> "
@@ -495,8 +436,8 @@ msgstr ""
 "Ausgabe in eine Datei namens B<linkchecker-out.>I<TYP>, B<$HOME/.linkchecker/"
 "blacklist> bei B<blacklist> Ausgabe, oder I<DATEINAME> falls angegeben. Das "
 "I<ENCODING> gibt die Ausgabekodierung an. Der Standard ist das der lokalen "
-"Spracheinstellung. Gültige Enkodierungen sind aufgelistet unter B<http://"
-"docs.python.org/library/\\:codecs.html#standard-encodings>."
+"Spracheinstellung. Gültige Enkodierungen sind aufgelistet unter E<.UR "
+"https://docs.python.org/library/codecs.html#standard-encodings> E<.UE .>"
 
 # type: Plain text
 #. type: Plain text
@@ -567,19 +508,14 @@ msgstr ""
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:132 en/linkcheckerrc.5:194
-#, fuzzy
-#| msgid ""
-#| "The I<ENCODING> specifies the output encoding, the default is that of "
-#| "your locale. Valid encodings are listed at B<http://docs.python.org/"
-#| "library/codecs.html#standard-encodings>."
 msgid ""
 "The I<ENCODING> specifies the output encoding, the default is that of your "
 "locale. Valid encodings are listed at E<.UR https://docs.python.org/library/"
 "codecs.html#standard-encodings> E<.UE .>"
 msgstr ""
 "Das I<ENCODING> gibt die Ausgabekodierung an. Der Standard ist das der "
-"lokalen Spracheinstellung. Gültige Enkodierungen sind aufgelistet unter "
-"B<http://docs.python.org/library/codecs.html#standard-encodings>."
+"lokalen Spracheinstellung. Gültige Enkodierungen sind aufgelistet unter E<."
+"UR https://docs.python.org/library/codecs.html#standard-encodings> E<.UE .>"
 
 # type: TP
 #. type: TP
@@ -685,10 +621,9 @@ msgstr ""
 # type: TP
 #. type: TP
 #: en/linkchecker.1:157
-#, fuzzy, no-wrap
-#| msgid "B<--check-html>"
+#, no-wrap
 msgid "B<--check-extern>"
-msgstr "B<--check-html>"
+msgstr "B<--check-extern>"
 
 #. type: Plain text
 #: en/linkchecker.1:160
@@ -852,11 +787,6 @@ msgstr "KONFIGURATIONSDATEIEN"
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:211
-#, fuzzy
-#| msgid ""
-#| "Configuration files can specify all options above. They can also specify "
-#| "some options that cannot be set on the command line.  See "
-#| "B<linkcheckerrc>(5) for more info."
 msgid ""
 "Configuration files can specify all options above. They can also specify "
 "some options that cannot be set on the command line.  See "
@@ -992,16 +922,12 @@ msgstr "B<sitemap>"
 
 #. type: Plain text
 #: en/linkchecker.1:245
-#, fuzzy
-#| msgid ""
-#| "Log check result as an XML sitemap whose protocol is documented at "
-#| "B<http://www.sitemaps.org/protocol.html>."
 msgid ""
 "Log check result as an XML sitemap whose protocol is documented at E<.UR "
 "https://www.sitemaps.org/protocol.html> E<.UE .>"
 msgstr ""
-"Protokolliere Prüfergebnisse als XML Sitemap dessen Format unter B<http://"
-"www.sitemaps.org/protocol.html> dokumentiert ist."
+"Protokolliere Prüfergebnisse als XML Sitemap dessen Format unter E<.UR "
+"https://www.sitemaps.org/protocol.html> E<.UE .> dokumentiert ist."
 
 # type: TP
 #. type: TP
@@ -1063,16 +989,12 @@ msgstr "REGULÄRE AUSDRÜCKE"
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:264
-#, fuzzy
-#| msgid ""
-#| "LinkChecker accepts Python regular expressions.  See B<http://docs.python."
-#| "org/\\:howto/regex.html> for an introduction."
 msgid ""
 "LinkChecker accepts Python regular expressions.  See E<.UR https://docs."
 "python.org/howto/regex.html> E<.UE> for an introduction."
 msgstr ""
-"LinkChecker akzeptiert Pythons reguläre Ausdrücke. Siehe B<http://docs."
-"python.org/\\:howto/regex.html> für eine Einführung."
+"LinkChecker akzeptiert Pythons reguläre Ausdrücke. Siehe E<.UR https://docs."
+"python.org/howto/regex.html> E<.UE> für eine Einführung."
 
 # type: Plain text
 #. type: Plain text
@@ -1130,10 +1052,9 @@ msgstr "Gibt den Pfad für den die Cookies gültig sind; Standardpfad ist B</>."
 # type: TP
 #. type: TP
 #: en/linkchecker.1:278
-#, fuzzy, no-wrap
-#| msgid "B<Host> (required)"
+#, no-wrap
 msgid "B<Set-cookie> (required)"
-msgstr "B<Host> (erforderlich)"
+msgstr "B<Set-cookie> (erforderlich)"
 
 # type: Plain text
 #. type: Plain text
@@ -1162,12 +1083,7 @@ msgstr ""
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:292
-#, fuzzy, no-wrap
-#| msgid ""
-#| " Host: example.com\n"
-#| " Path: /hello\n"
-#| " Set-cookie: ID=\"smee\"\n"
-#| " Set-cookie: spam=\"egg\"\n"
+#, no-wrap
 msgid ""
 "  Host: example.com\n"
 "  Path: /hello\n"
@@ -1182,18 +1098,13 @@ msgstr ""
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:295
-#, fuzzy, no-wrap
-#| msgid ""
-#| " Scheme: https\n"
-#| " Host: example.org\n"
-#| " Set-cookie: baggage=\"elitist\"; comment=\"hologram\"\n"
+#, no-wrap
 msgid ""
 "  Host: example.org\n"
 "  Set-cookie: baggage=\"elitist\"; comment=\"hologram\"\n"
 msgstr ""
-" Scheme: https\n"
-" Host: example.org\n"
-" Set-cookie: baggage=\"elitist\"; comment=\"hologram\"\n"
+"  Host: example.org\n"
+"  Set-cookie: baggage=\"elitist\"; comment=\"hologram\"\n"
 
 # type: SH
 #. type: SH
@@ -1205,13 +1116,6 @@ msgstr "PROXY UNTERSTÜTZUNG"
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:303
-#, fuzzy
-#| msgid ""
-#| "To use a proxy on Unix or Windows set the $http_proxy, $https_proxy or "
-#| "$ftp_proxy environment variables to the proxy URL. The URL should be of "
-#| "the form B<http://>[I<user>B<:>I<pass>B<@>]I<host>[B<:>I<port>].  "
-#| "LinkChecker also detects manual proxy settings of Internet Explorer under "
-#| "Windows systems. On a Mac use the Internet Config to select a proxy."
 msgid ""
 "To use a proxy on Unix or Windows set the $http_proxy, $https_proxy or "
 "$ftp_proxy environment variables to the proxy URL. The URL should be of the "
@@ -1247,10 +1151,8 @@ msgstr "Einen HTTP-Proxy unter Unix anzugeben sieht beispielsweise so aus:"
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:310
-#, fuzzy
-#| msgid "  export http_proxy=\"http://proxy.example.com:8080\"\n"
 msgid "B<export http_proxy=\"http://proxy.example.com:8080\">"
-msgstr "  export http_proxy=\"http://proxy.example.com:8080\"\n"
+msgstr "B<export http_proxy=\"http://proxy.example.com:8080\">"
 
 # type: Plain text
 #. type: TP
@@ -1262,10 +1164,8 @@ msgstr "Proxy-Authentifizierung wird ebenfalls unterstützt:"
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:314
-#, fuzzy
-#| msgid "  export http_proxy=\"http://user1:mypass@proxy.example.org:8081\"\n"
 msgid "B<export http_proxy=\"http://user1:mypass@proxy.example.org:8081\">"
-msgstr "  export http_proxy=\"http://user1:mypass@proxy.example.org:8081\"\n"
+msgstr "B<export http_proxy=\"http://user1:mypass@proxy.example.org:8081\">"
 
 # type: Plain text
 #. type: TP
@@ -1277,10 +1177,8 @@ msgstr "Setzen eines Proxies unter der Windows Befehlszeile:"
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:318
-#, fuzzy
-#| msgid "  set http_proxy=http://proxy.example.com:8080\n"
 msgid "B<set http_proxy=http://proxy.example.com:8080>"
-msgstr "  set http_proxy=http://proxy.example.com:8080\n"
+msgstr "B<set http_proxy=http://proxy.example.com:8080>"
 
 #. type: SH
 #: en/linkchecker.1:318
@@ -1411,103 +1309,77 @@ msgstr "FTP-Links (B<ftp:>)"
 #, fuzzy
 #| msgid "  For FTP links we do:\n"
 msgid "For FTP links we do:"
-msgstr "Für FTP-Links wird Folgendes geprüft:\n"
+msgstr "Für FTP-Links wird Folgendes geprüft:"
 
 #. type: Plain text
 #: en/linkchecker.1:362
 msgid "1) connect to the specified host"
-msgstr ""
+msgstr "1) Eine Verbindung zum angegeben Rechner wird aufgebaut"
 
 #. type: Plain text
 #: en/linkchecker.1:365
-#, fuzzy
-#| msgid ""
-#| "  1) connect to the specified host\n"
-#| "  2) try to login with the given user and password. The default\n"
-#| "     user is ``anonymous``, the default password is ``anonymous@``.\n"
-#| "  3) try to change to the given directory\n"
-#| "  4) list the file with the NLST command\n"
 msgid ""
 "2) try to login with the given user and password. The default user is "
 "B<anonymous>, the default password is B<anonymous@>."
 msgstr ""
-"  1) Eine Verbindung zum angegeben Rechner wird aufgebaut\n"
-"  2) Versuche, sich mit dem gegebenen Nutzer und Passwort anzumelden. Der "
-"Standardbenutzer ist ``anonymous``, das Standardpasswort ist "
-"``anonymous@``.\n"
-"  3) Versuche, in das angegebene Verzeichnis zu wechseln\n"
-"  4) Liste die Dateien im Verzeichnis auf mit dem NLST-Befehl\n"
+"2) Versuche, sich mit dem gegebenen Nutzer und Passwort anzumelden. Der "
+"Standardbenutzer ist ``anonymous``, das Standardpasswort ist ``anonymous@``."
 
 #. type: Plain text
 #: en/linkchecker.1:367
 msgid "3) try to change to the given directory"
-msgstr ""
+msgstr "3) Versuche, in das angegebene Verzeichnis zu wechseln"
 
 #. type: Plain text
 #: en/linkchecker.1:369
 msgid "4) list the file with the NLST command"
-msgstr ""
+msgstr "4) Liste die Dateien im Verzeichnis auf mit dem NLST-Befehl"
 
 #. type: TP
 #: en/linkchecker.1:370
-#, fuzzy, no-wrap
-#| msgid "Telnet links (``telnet:``)"
+#, no-wrap
 msgid "Telnet links (B<telnet:>)"
-msgstr "Telnet-Links (``telnet:``)"
+msgstr "Telnet links (B<telnet:>)"
 
 #. type: Plain text
 #: en/linkchecker.1:374
-#, fuzzy
-#| msgid ""
-#| "  We try to connect and if user/password are given, login to the\n"
-#| "  given telnet server.\n"
 msgid ""
 "We try to connect and if user/password are given, login to the given telnet "
 "server."
 msgstr ""
-"  Versuche, zu dem angegeben Telnetrechner zu verginden und falls Benutzer/"
-"Passwort angegeben sind, wird versucht, sich anzumelden.\n"
+"Versuche, zu dem angegeben Telnetrechner zu verginden und falls Benutzer/"
+"Passwort angegeben sind, wird versucht, sich anzumelden."
 
 #. type: TP
 #: en/linkchecker.1:375
-#, fuzzy, no-wrap
-#| msgid "NNTP links (``news:``, ``snews:``, ``nntp``)"
+#, no-wrap
 msgid "NNTP links (B<news:>, B<snews:>, B<nntp>)"
-msgstr "NNTP-Links (``news:``, ``snews:``, ``nntp``)"
+msgstr "NNTP links (B<news:>, B<snews:>, B<nntp>)"
 
 #. type: Plain text
 #: en/linkchecker.1:379
-#, fuzzy
-#| msgid ""
-#| "  We try to connect to the given NNTP server. If a news group or\n"
-#| "  article is specified, try to request it from the server.\n"
 msgid ""
 "We try to connect to the given NNTP server. If a news group or article is "
 "specified, try to request it from the server."
 msgstr ""
-"  Versuche, zu dem angegebenen NNTP-Rechner eine Verbindung aufzubaucne. "
-"Falls eine Nachrichtengruppe oder ein bestimmter Artikel angegeben ist, wird "
-"versucht, diese Gruppe oder diesen Artikel vom Rechner anzufragen.\n"
+"Versuche, zu dem angegebenen NNTP-Rechner eine Verbindung aufzubaucne. Falls "
+"eine Nachrichtengruppe oder ein bestimmter Artikel angegeben ist, wird "
+"versucht, diese Gruppe oder diesen Artikel vom Rechner anzufragen."
 
 #. type: TP
 #: en/linkchecker.1:380
-#, fuzzy, no-wrap
-#| msgid "Unsupported links (``javascript:``, etc.)"
+#, no-wrap
 msgid "Unsupported links (B<javascript:>, etc.)"
-msgstr "Nicht unterstützte Links (``javascript:``, etc.)"
+msgstr "Nicht unterstützte Links (B<javascript:>, etc.)"
 
 #. type: Plain text
 #: en/linkchecker.1:384
-#, fuzzy
-#| msgid ""
-#| "  An unsupported link will only print a warning. No further checking\n"
-#| "  will be made.\n"
 msgid ""
 "An unsupported link will only print a warning. No further checking will be "
 "made."
 msgstr ""
-"  Ein nicht unterstützter Link wird nur eine Warnung ausgeben. Weitere "
-"Prüfungen werden nicht durchgeführt.\n"
+"Ein nicht unterstützter Link wird nur eine Warnung ausgeben. Weitere "
+"Prüfungen werden nicht durchgeführt."
 
 #. type: Plain text
 #: en/linkchecker.1:392
@@ -1522,9 +1394,8 @@ msgid ""
 "checker/unknownurl.py> linkcheck/checker/unknownurl.py E<.UE> source file.  "
 "The most prominent of them should be JavaScript links."
 msgstr ""
-"  Die komplette Liste von erkannten, aber nicht unterstützten Links ist in "
-"der\n"
-"  Quelldatei B<linkcheck/checker/unknownurl.py>. Die bekanntesten davon "
+"Die komplette Liste von erkannten, aber nicht unterstützten Links ist in der "
+"Quelldatei B<linkcheck/checker/unknownurl.py>. Die bekanntesten davon "
 "dürften JavaScript-Links sein.\n"
 
 #. type: SH
@@ -1822,30 +1693,22 @@ msgstr "B<linkchecker-out.>I<TYP> - Standard Dateiname der Logausgabe"
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:493
-#, fuzzy
-#| msgid ""
-#| "B<http://docs.python.org/library/codecs.html#standard-encodings> - valid "
-#| "output encodings"
 msgid ""
 "E<.UR https://docs.python.org/library/codecs.html#standard-encodings> E<.UE> "
 "- valid output encodings"
 msgstr ""
-"B<http://docs.python.org/library/codecs.html#standard-encodings> - gültige "
-"Ausgabe Enkodierungen"
+"E<.UR https://docs.python.org/library/codecs.html#standard-encodings> E<.UE> "
+"- gültige Ausgabe Enkodierungen"
 
 # type: Plain text
 #. type: Plain text
 #: en/linkchecker.1:497
-#, fuzzy
-#| msgid ""
-#| "B<http://docs.python.org/howto/regex.html> - regular expression "
-#| "documentation"
 msgid ""
 "E<.UR https://docs.python.org/howto/regex.html> E<.UE> - regular expression "
 "documentation"
 msgstr ""
-"B<http://docs.python.org/howto/regex.html> - Dokumentation zu regulären "
-"Ausdrücken"
+"E<.UR https://docs.python.org/howto/regex.html> E<.UE> - Dokumentation zu "
+"regulären Ausdrücken"
 
 # type: SH
 #. type: SH
@@ -1889,10 +1752,9 @@ msgstr "Copyright \\(co 2000-2014 Bastian Kleineidam"
 # type: TH
 #. type: TH
 #: en/linkcheckerrc.5:1
-#, fuzzy, no-wrap
-#| msgid "LINKCHECKER"
+#, no-wrap
 msgid "LINKCHECKERRC"
-msgstr "LINKCHECKER"
+msgstr "LINKCHECKERRC"
 
 # type: Plain text
 #. type: Plain text
@@ -1943,16 +1805,12 @@ msgstr "B<cookiefile=>I<Dateiname>"
 # type: Plain text
 #. type: Plain text
 #: en/linkcheckerrc.5:18
-#, fuzzy
-#| msgid ""
-#| "Read a file with initial cookie data. The cookie data format is explained "
-#| "in linkchecker(1)."
 msgid ""
 "Read a file with initial cookie data. The cookie data format is explained in "
 "B<linkchecker>(1)."
 msgstr ""
 "Lese eine Datei mit Cookie-Daten. Das Cookie Datenformat wird in "
-"linkchecker(1) erklärt."
+"B<linkchecker>(1) erklärt."
 
 # type: Plain text
 #. type: Plain text
@@ -2051,10 +1909,9 @@ msgstr "Kommandozeilenoption: B<--timeout>"
 # type: TP
 #. type: TP
 #: en/linkcheckerrc.5:56
-#, fuzzy, no-wrap
-#| msgid "B<timeout=>I<NUMBER>"
+#, no-wrap
 msgid "B<aborttimeout=>I<NUMBER>"
-msgstr "B<timeout=>I<NUMMER>"
+msgstr "B<aborttimeout=>I<NUMMER>"
 
 #. type: Plain text
 #: en/linkcheckerrc.5:61
@@ -2141,10 +1998,9 @@ msgstr "Standard ist alle URLs anzunehmen und zu prüfen."
 # type: TP
 #. type: TP
 #: en/linkcheckerrc.5:94
-#, fuzzy, no-wrap
-#| msgid "B<maxrunseconds=>I<NUMBER>"
+#, no-wrap
 msgid "B<maxrequestspersecond=>I<NUMBER>"
-msgstr "B<maxrunseconds=>I<NUMBER>"
+msgstr "B<maxrequestspersecond=>I<NUMMER>"
 
 #. type: Plain text
 #: en/linkcheckerrc.5:97
@@ -2154,10 +2010,9 @@ msgstr ""
 # type: TP
 #. type: TP
 #: en/linkcheckerrc.5:97
-#, fuzzy, no-wrap
-#| msgid "B<ignorewarnings=>I<NAME>[B<,>I<NAME>...]"
+#, no-wrap
 msgid "B<allowedschemes=>I<NAME>[B<,>I<NAME>...]"
-msgstr "B<ignorewarnings=>I<NAME>[B<,>I<NAME>...]"
+msgstr "B<allowedschemes=>I<NAME>[B<,>I<NAME>...]"
 
 #. type: Plain text
 #: en/linkcheckerrc.5:100
@@ -2255,10 +2110,9 @@ msgstr "Kommandozeilenoption: B<--no-follow-url>"
 # type: TP
 #. type: TP
 #: en/linkcheckerrc.5:124
-#, fuzzy, no-wrap
-#| msgid "B<checkhtml=>[B<0>|B<1>]"
+#, no-wrap
 msgid "B<checkextern=>[B<0>|B<1>]"
-msgstr "B<checkhtml=>[B<0>|B<1>]"
+msgstr "B<checkextern=>[B<0>|B<1>]"
 
 #. type: Plain text
 #: en/linkcheckerrc.5:127
@@ -2268,10 +2122,8 @@ msgstr ""
 # type: Plain text
 #. type: Plain text
 #: en/linkcheckerrc.5:129
-#, fuzzy
-#| msgid "Command line option: B<--check-html>"
 msgid "Command line option: B<--checkextern>"
-msgstr "Kommandozeilenoption: B<--check-html>"
+msgstr "Kommandozeilenoption: B<--checkextern>"
 
 # type: SS
 #. type: SS
@@ -2636,16 +2488,12 @@ msgstr "B<encoding=>I<STRING>"
 # type: Plain text
 #. type: Plain text
 #: en/linkcheckerrc.5:235
-#, fuzzy
-#| msgid ""
-#| "Valid encodings are listed in B<http://docs.python.org/library/codecs."
-#| "html#standard-encodings>."
 msgid ""
 "Valid encodings are listed in E<.UR https://docs.python.org/library/codecs."
 "html#standard-encodings> E<.UE .>"
 msgstr ""
-"Gültige Enkodierungen sind aufgelistet unter B<http://docs.python.org/"
-"library/codecs.html#standard-encodings>."
+"Gültige Enkodierungen sind aufgelistet unter E<.UR https://docs.python.org/"
+"library/codecs.html#standard-encodings> E<.UE .>"
 
 #. type: Plain text
 #: en/linkcheckerrc.5:237
@@ -2905,8 +2753,6 @@ msgstr "Setze Datenbankname zum Speichern. Standard ist B<linksdb>."
 # type: Plain text
 #. type: Plain text
 #: en/linkcheckerrc.5:333
-#, fuzzy
-#| msgid "Set SQL command separator character. Default is a semicolor (B<;>)."
 msgid "Set SQL command separator character. Default is a semicolon (B<;>)."
 msgstr "Setze SQL Kommandotrennzeichen. Standard ist ein Strichpunkt (B<;>)."
 
@@ -3059,8 +2905,6 @@ msgstr "B<frequency=>[B<always>|B<hourly>|B<daily>|B<weekly>|B<monthly>|B<yearly
 
 #. type: Plain text
 #: en/linkcheckerrc.5:408
-#, fuzzy
-#| msgid "The frequence pages are changing with."
 msgid "How frequently pages are changing."
 msgstr "Die Häufigkeit mit der Seiten sich ändern."
 
@@ -3075,7 +2919,7 @@ msgstr "AUSGABE PARTS"
 #: en/linkcheckerrc.5:413
 #, no-wrap
 msgid "B<all>"
-msgstr ""
+msgstr "B<all>"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:413
@@ -3087,7 +2931,7 @@ msgstr ""
 #: en/linkcheckerrc.5:414
 #, no-wrap
 msgid "B<id>"
-msgstr ""
+msgstr "B<id>"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:414
@@ -3099,7 +2943,7 @@ msgstr ""
 #: en/linkcheckerrc.5:415
 #, no-wrap
 msgid "B<realurl>"
-msgstr ""
+msgstr "B<realurl>"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:415
@@ -3111,7 +2955,7 @@ msgstr ""
 #: en/linkcheckerrc.5:416
 #, no-wrap
 msgid "B<result>"
-msgstr ""
+msgstr "B<result>"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:416
@@ -3122,10 +2966,9 @@ msgstr ""
 # type: TP
 #. type: tbl table
 #: en/linkcheckerrc.5:417
-#, fuzzy, no-wrap
-#| msgid "B<--check-html>"
+#, no-wrap
 msgid "B<extern>"
-msgstr "B<--check-html>"
+msgstr "B<extern>"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:417
@@ -3137,31 +2980,31 @@ msgstr ""
 #: en/linkcheckerrc.5:418
 #, no-wrap
 msgid "B<base>"
-msgstr ""
+msgstr "B<base>"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:418
 #, no-wrap
 msgid "(base href=...)"
-msgstr ""
+msgstr "(base href=...)"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:419
 #, no-wrap
 msgid "B<name>"
-msgstr ""
+msgstr "B<name>"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:419
 #, no-wrap
 msgid "(E<lt>a href=...E<gt>nameE<lt>/aE<gt> and E<lt>img alt=\"name\"E<gt>)"
-msgstr ""
+msgstr "(E<lt>a href=...E<gt>nameE<lt>/aE<gt> and E<lt>img alt=\"name\"E<gt>)"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:420
 #, no-wrap
 msgid "B<parenturl>"
-msgstr ""
+msgstr "B<parenturl>"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:420
@@ -3173,7 +3016,7 @@ msgstr ""
 #: en/linkcheckerrc.5:421
 #, no-wrap
 msgid "B<info>"
-msgstr ""
+msgstr "B<info>"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:421
@@ -3184,10 +3027,9 @@ msgstr ""
 # type: TP
 #. type: tbl table
 #: en/linkcheckerrc.5:422
-#, fuzzy, no-wrap
-#| msgid "B<--no-warnings>"
+#, no-wrap
 msgid "B<warning>"
-msgstr "B<--no-warnings>"
+msgstr "B<warning>"
 
 # type: TP
 #. type: tbl table
@@ -3201,7 +3043,7 @@ msgstr "B<--no-warnings>"
 #: en/linkcheckerrc.5:423
 #, no-wrap
 msgid "B<dltime>"
-msgstr ""
+msgstr "B<dltime>"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:423
@@ -3212,10 +3054,9 @@ msgstr ""
 # type: TP
 #. type: tbl table
 #: en/linkcheckerrc.5:424
-#, fuzzy, no-wrap
-#| msgid "B<--check-html>"
+#, no-wrap
 msgid "B<checktime>"
-msgstr "B<--check-html>"
+msgstr "B<checktime>"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:424
@@ -3227,7 +3068,7 @@ msgstr ""
 #: en/linkcheckerrc.5:425
 #, no-wrap
 msgid "B<url>"
-msgstr ""
+msgstr "B<url>"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:425
@@ -3239,7 +3080,7 @@ msgstr ""
 #: en/linkcheckerrc.5:426
 #, no-wrap
 msgid "B<intro>"
-msgstr ""
+msgstr "B<intro>"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:426
@@ -3251,7 +3092,7 @@ msgstr ""
 #: en/linkcheckerrc.5:427
 #, no-wrap
 msgid "B<outro>"
-msgstr ""
+msgstr "B<outro>"
 
 #. type: tbl table
 #: en/linkcheckerrc.5:427
@@ -3281,13 +3122,7 @@ msgstr ""
 # type: Plain text
 #. type: Plain text
 #: en/linkcheckerrc.5:439
-#, fuzzy, no-wrap
-#| msgid ""
-#| " ignore=\n"
-#| "   lconline\n"
-#| "   bookmark\n"
-#| "   # a comment\n"
-#| "   ^mailto:\n"
+#, no-wrap
 msgid ""
 "ignore=\n"
 "  lconline\n"
@@ -3295,10 +3130,11 @@ msgid ""
 "  # a comment\n"
 "  ^mailto:\n"
 msgstr ""
-" ignore=\n"
-"   lconline\n"
-"   bookmark\n"
-"   # a comment   ^mailto:\n"
+"ignore=\n"
+"  lconline\n"
+"  bookmark\n"
+"  # a comment\n"
+"  ^mailto:\n"
 
 # type: SH
 #. type: SH
@@ -3310,44 +3146,35 @@ msgstr "BEISPIEL"
 # type: Plain text
 #. type: Plain text
 #: en/linkcheckerrc.5:444
-#, fuzzy, no-wrap
-#| msgid ""
-#| " [output]\n"
-#| " log=html\n"
+#, no-wrap
 msgid ""
 "[output]\n"
 "log=html\n"
 msgstr ""
-" [output]\n"
-" log=html\n"
+"[output]\n"
+"log=html\n"
 
 # type: Plain text
 #. type: Plain text
 #: en/linkcheckerrc.5:447
-#, fuzzy, no-wrap
-#| msgid ""
-#| " [checking]\n"
-#| " threads=5\n"
+#, no-wrap
 msgid ""
 "[checking]\n"
 "threads=5\n"
 msgstr ""
-" [checking]\n"
-" threads=5\n"
+"[checking]\n"
+"threads=5\n"
 
 # type: Plain text
 #. type: Plain text
 #: en/linkcheckerrc.5:450
-#, fuzzy, no-wrap
-#| msgid ""
-#| " [filtering]\n"
-#| " ignorewarnings=http-moved-permanent\n"
+#, no-wrap
 msgid ""
 "[filtering]\n"
 "ignorewarnings=http-moved-permanent\n"
 msgstr ""
-" [filtering]\n"
-" ignorewarnings=http-moved-permanent\n"
+"[filtering]\n"
+"ignorewarnings=http-moved-permanent\n"
 
 #. type: Plain text
 #: en/linkcheckerrc.5:455
@@ -3360,10 +3187,9 @@ msgstr ""
 # type: SS
 #. type: SS
 #: en/linkcheckerrc.5:456
-#, fuzzy, no-wrap
-#| msgid "[checking]"
+#, no-wrap
 msgid "[AnchorCheck]"
-msgstr "[checking]"
+msgstr "[AnchorCheck]"
 
 #. type: Plain text
 #: en/linkcheckerrc.5:458
@@ -3374,7 +3200,7 @@ msgstr ""
 #: en/linkcheckerrc.5:459
 #, no-wrap
 msgid "[LocationInfo]"
-msgstr ""
+msgstr "[LocationInfo]"
 
 #. type: Plain text
 #: en/linkcheckerrc.5:462
@@ -3387,7 +3213,7 @@ msgstr ""
 #: en/linkcheckerrc.5:463
 #, no-wrap
 msgid "[RegexCheck]"
-msgstr ""
+msgstr "[RegexCheck]"
 
 # type: Plain text
 #. type: Plain text
@@ -3409,10 +3235,9 @@ msgstr ""
 # type: TP
 #. type: TP
 #: en/linkcheckerrc.5:467
-#, fuzzy, no-wrap
-#| msgid "B<-W>I<REGEX>, B<--warning-regex=>I<REGEX>"
+#, no-wrap
 msgid "B<warningregex=>I<REGEX>"
-msgstr "B<-W>I<REGEX>, B<--warning-regex=>I<REGEX>"
+msgstr "B<warningregex=>I<REGEX>"
 
 # type: Plain text
 #. type: Plain text
@@ -3434,7 +3259,7 @@ msgstr ""
 #: en/linkcheckerrc.5:476
 #, no-wrap
 msgid "[SslCertificateCheck]"
-msgstr ""
+msgstr "[SslCertificateCheck]"
 
 #. type: Plain text
 #: en/linkcheckerrc.5:480
@@ -3460,7 +3285,7 @@ msgstr ""
 #: en/linkcheckerrc.5:484
 #, no-wrap
 msgid "[HtmlSyntaxCheck]"
-msgstr ""
+msgstr "[HtmlSyntaxCheck]"
 
 # type: Plain text
 #. type: Plain text
@@ -3476,7 +3301,7 @@ msgstr "Prüfe Syntax von HTML URLs mit dem W3C Online Validator."
 #: en/linkcheckerrc.5:490
 #, no-wrap
 msgid "[HttpHeaderInfo]"
-msgstr ""
+msgstr "[HttpHeaderInfo]"
 
 #. type: Plain text
 #: en/linkcheckerrc.5:492
@@ -3487,7 +3312,7 @@ msgstr ""
 #: en/linkcheckerrc.5:492
 #, no-wrap
 msgid "B<prefixes=>I<prefix1>[,I<prefix2>]..."
-msgstr ""
+msgstr "B<prefixes=>I<prefix1>[,I<prefix2>]..."
 
 #. type: Plain text
 #: en/linkcheckerrc.5:496
@@ -3500,7 +3325,7 @@ msgstr ""
 #: en/linkcheckerrc.5:497
 #, no-wrap
 msgid "[CssSyntaxCheck]"
-msgstr ""
+msgstr "[CssSyntaxCheck]"
 
 # type: Plain text
 #. type: Plain text
@@ -3516,7 +3341,7 @@ msgstr "Prüfe Syntax von HTML URLs mit dem W3C Online Validator."
 #: en/linkcheckerrc.5:503
 #, no-wrap
 msgid "[VirusCheck]"
-msgstr ""
+msgstr "[VirusCheck]"
 
 #. type: Plain text
 #: en/linkcheckerrc.5:506
@@ -3542,7 +3367,7 @@ msgstr "Dateiname von B<clamd.conf> Konfigurationsdatei."
 #: en/linkcheckerrc.5:510
 #, no-wrap
 msgid "[PdfParser]"
-msgstr ""
+msgstr "[PdfParser]"
 
 #. type: Plain text
 #: en/linkcheckerrc.5:513
@@ -3555,7 +3380,7 @@ msgstr ""
 #: en/linkcheckerrc.5:514
 #, no-wrap
 msgid "[WordParser]"
-msgstr ""
+msgstr "[WordParser]"
 
 #. type: Plain text
 #: en/linkcheckerrc.5:517
@@ -3738,10 +3563,8 @@ msgstr "Die URL %(url)s enthält Leerzeichen am Anfang oder Ende."
 # type: TH
 #. type: Plain text
 #: en/linkcheckerrc.5:567
-#, fuzzy
-#| msgid "linkchecker(1)"
 msgid "B<linkchecker>(1)"
-msgstr "BEISPIEL"
+msgstr "B<linkchecker>(1)"
 
 #, no-wrap
 #~ msgid "2010-07-01"

--- a/doc/de/linkchecker.1
+++ b/doc/de/linkchecker.1
@@ -3,16 +3,14 @@
 .\" This file was generated with po4a. Translate the source file.
 .\"
 .\"*******************************************************************
-.TH LINKCHECKER 1 2010\-07\-01 LinkChecker "LinkChecker auf der Kommandozeile"
+.TH LINKCHECKER 1 2020\-04\-24 LinkChecker "LinkChecker User Manual"
 .SH NAME
 linkchecker \- Kommandozeilenprogramm zum Prüfen von HTML Dokumenten und
 Webseiten auf ungültige Verknüpfungen
-.
 .SH SYNTAX
 \fBlinkchecker\fP [\fIOptionen\fP] [\fIDatei\-oder\-URL\fP]...
-.
 .SH BESCHREIBUNG
-.LP
+.TP  2
 LinkChecker beinhaltet
 .IP \(bu
 rekursives Prüfen und Multithreading
@@ -41,31 +39,31 @@ Antivirusprüfung
 .IP \(bu
 ein Kommandozeilenprogramm und web interface
 .SH BEISPIELE
+.TP  2
 The most common use checks the given domain recursively:
-  \fBlinkchecker http://www.example.com/\fP
+\fBlinkchecker http://www.example.com/\fP
 .br
 Beachten Sie dass dies die komplette Domäne überprüft, welche aus mehreren
 tausend URLs bestehen kann. Benutzen Sie die Option \fB\-r\fP, um die
 Rekursionstiefe zu beschränken.
-.br
+.TP 
 Don't check URLs with \fB/secret\fP in its name. All other links are checked as usual:
-  \fBlinkchecker \-\-ignore\-url=/secret mysite.example.com\fP
-.br
-Überprüfung einer lokalen HTML Datei unter Unix:
-  \fBlinkchecker ../bla.html\fP
-.br
-Überprüfung einer lokalen HTML Datei unter Windows:
-  \fBlinkchecker c:\etemp\etest.html\fP
-.br
-Sie können den \fBhttp://\fP URL Anteil weglassen wenn die Domäne mit \fBwww.\fP beginnt:
-  \fBlinkchecker www.example.com\fP
-.br
+\fBlinkchecker \-\-ignore\-url=/secret mysite.example.com\fP
+.TP 
+Checking a local HTML file on Unix:
+\fBlinkchecker ../bla.html\fP
+.TP 
+Checking a local HTML file on Windows:
+\fBlinkchecker c:\temp\test.html\fP
+.TP 
+You can skip the \fBhttp://\fP url part if the domain starts with \fBwww.\fP:
+\fBlinkchecker www.example.com\fP
+.TP 
 You can skip the \fBftp://\fP url part if the domain starts with \fBftp.\fP:
-  \fBlinkchecker \-r0 ftp.example.com\fP
-.br
-Erzeuge einen Sitemap Graphen und konvertiere ihn mit dem graphviz dot Programm:
-  \fBlinkchecker \-odot \-v www.example.com | dot \-Tps > sitemap.ps\fP
-.
+\fBlinkchecker \-r0 ftp.example.com\fP
+.TP 
+Generate a sitemap graph and convert it with the graphviz dot utility:
+\fBlinkchecker \-odot \-v www.example.com | dot \-Tps > sitemap.ps\fP
 .SH OPTIONEN
 .SS "Allgemeine Optionen"
 .TP 
@@ -93,19 +91,19 @@ Print available check plugins and exit.
 .SS Ausgabeoptionen
 .TP 
 \fB\-D\fP\fINAME\fP, \fB\-\-debug=\fP\fINAME\fP
-Gebe Testmeldungen aus für den angegebenen Logger. Verfügbare Logger sind
-\fBcmdline\fP, \fBchecking\fP,\fBcache\fP, \fBdns\fP, \fBplugins\fP und \fBall\fP. Die Angabe
-\fBall\fP ist ein Synonym für alle verfügbaren Logger. Diese Option kann
-mehrmals angegeben werden, um mit mehr als einem Logger zu testen. Um
-akkurate Ergebnisse zu erzielen, werden Threads deaktiviert.
+Print debugging output for the given logger.  Available loggers are
+\fBcmdline\fP, \fBchecking\fP, \fBcache\fP, \fBdns\fP, \fBplugin\fP and \fBall\fP.  Specifying
+\fBall\fP is an alias for specifying all available loggers.  The option can be
+given multiple times to debug with more than one logger.  For accurate
+results, threading will be disabled during debug runs.
 .TP 
 \fB\-F\fP\fITYP\fP[\fB/\fP\fIENKODIERUNG\fP][\fB/\fP\fIDATEINAME\fP], \fB\-\-file\-output=\fP\fITYP\fP[\fB/\fP\fIENKODIERUNG\fP][\fB/\fP\fIDATEINAME\fP]
-Ausgabe in eine Datei namens \fBlinkchecker\-out.\fP\fITYP\fP,
-\fB$HOME/.linkchecker/blacklist\fP bei \fBblacklist\fP Ausgabe, oder \fIDATEINAME\fP
-falls angegeben. Das \fIENCODING\fP gibt die Ausgabekodierung an. Der Standard
-ist das der lokalen Spracheinstellung. Gültige Enkodierungen sind
-aufgelistet unter
-\fBhttp://docs.python.org/library/\:codecs.html#standard\-encodings\fP.
+Output to a file \fBlinkchecker\-out.\fP\fITYPE\fP, \fB$HOME/.linkchecker/blacklist\fP
+for \fBblacklist\fP output, or \fIFILENAME\fP if specified.  The \fIENCODING\fP
+specifies the output encoding, the default is that of your locale.  Valid
+encodings are listed at
+.UR https://docs.python.org/library/codecs.html#standard\-encodings
+.UE .
 .br
 Der \fIDATEINAME\fP und \fIENKODIERUNG\fP Teil wird beim Ausgabetyp \fBnone\fP
 ignoriert, ansonsten wird die Datei überschrieben falls sie existiert. Sie
@@ -127,9 +125,10 @@ Gib Ausgabetyp als \fBtext\fP, \fBhtml\fP, \fBsql\fP, \fBcsv\fP, \fBgml\fP, \fBd
 \fBsitemap\fP, \fBnone\fP oder \fBblacklist\fP an.  Stadard Typ ist \fBtext\fP. Die
 verschiedenen Ausgabetypen sind unten dokumentiert.
 .br
-Das \fIENCODING\fP gibt die Ausgabekodierung an. Der Standard ist das der
-lokalen Spracheinstellung. Gültige Enkodierungen sind aufgelistet unter
-\fBhttp://docs.python.org/library/\:codecs.html#standard\-encodings\fP.
+The \fIENCODING\fP specifies the output encoding, the default is that of your
+locale. Valid encodings are listed at
+.UR https://docs.python.org/library/codecs.html#standard\-encodings
+.UE .
 .TP 
 \fB\-q\fP, \fB\-\-quiet\fP
 Keine Ausgabe, ein Alias für \fB\-o none\fP. Dies ist nur in Verbindung mit
@@ -207,9 +206,9 @@ z.B. "Mozilla/4.0". Der Standard ist "LinkChecker/X.Y", wobei X.Y die
 aktuelle Version von LinkChecker ist.
 
 .SH KONFIGURATIONSDATEIEN
-Konfigurationsdateien können alle obigen Optionen enthalten. Sie können
-zudem Optionen enthalten, welche nicht auf der Kommandozeile gesetzt werden
-können. Siehe \fBlinkcheckerrc\fP(5) für mehr Informationen.
+Configuration files can specify all options above. They can also specify
+some options that cannot be set on the command line.  See
+\fBlinkcheckerrc\fP(5)  for more info.
 
 .SH AUSGABETYPEN
 Beachten Sie, dass standardmäßig nur Fehler und Warnungen protokolliert
@@ -241,8 +240,9 @@ Gebe Prüfresultat als GraphXML\-Datei aus.
 Gebe Prüfresultat als maschinenlesbare XML\-Datei aus.
 .TP 
 \fBsitemap\fP
-Protokolliere Prüfergebnisse als XML Sitemap dessen Format unter
-\fBhttp://www.sitemaps.org/protocol.html\fP dokumentiert ist.
+Log check result as an XML sitemap whose protocol is documented at
+.UR https://www.sitemaps.org/protocol.html
+.UE .
 .TP 
 \fBsql\fP
 Gebe Prüfresultat als SQL Skript mit INSERT Befehlen aus. Ein
@@ -258,8 +258,10 @@ und die Anzahl der Fehlversuche enthält.
 Gibt nichts aus. Für Debugging oder Prüfen des Rückgabewerts geeignet.
 .
 .SH "REGULÄRE AUSDRÜCKE"
-LinkChecker akzeptiert Pythons reguläre Ausdrücke. Siehe
-\fBhttp://docs.python.org/\:howto/regex.html\fP für eine Einführung.
+LinkChecker accepts Python regular expressions.  See
+.UR https://docs.python.org/howto/regex.html
+.UE
+for an introduction.
 
 Eine Ergänzung ist, dass ein regulärer Ausdruck negiert wird falls er mit
 einem Ausrufezeichen beginnt.
@@ -283,15 +285,15 @@ Mehrere Einträge sind durch eine Leerzeile zu trennen.
 Das untige Beispiel sendet zwei Cookies zu allen URLs die mit
 \fBhttp://example.org/hello/\fP beginnen, und eins zu allen URLs die mit
 \fBhttps://example.org\fP beginnen:
-
- Host: example.com
- Path: /hello
- Set\-cookie: ID="smee"
- Set\-cookie: spam="egg"
-
- Host: example.org
- Set\-cookie: baggage="elitist"; comment="hologram"
-
+.EX
+  Host: example.com
+  Path: /hello
+  Set\-cookie: ID="smee"
+  Set\-cookie: spam="egg"
+.PP
+  Host: example.org
+  Set\-cookie: baggage="elitist"; comment="hologram"
+.EE
 .SH "PROXY UNTERSTÜTZUNG"
 To use a proxy on Unix or Windows set the $http_proxy, $https_proxy or
 $ftp_proxy environment variables to the proxy URL. The URL should be of the
@@ -299,37 +301,32 @@ form \fBhttp://\fP[\fIuser\fP\fB:\fP\fIpass\fP\fB@\fP]\fIhost\fP[\fB:\fP\fIport\
 also detects manual proxy settings of Internet Explorer under Windows
 systems, and gconf or KDE on Linux systems.  On a Mac use the Internet
 Config to select a proxy.
-.
+.PP
 Sie können eine komma\-separierte Liste von Domainnamen in der $no_proxy
 Umgebungsvariable setzen, um alle Proxies für diese Domainnamen zu
 ignorieren.
-.
+.TP 
 Einen HTTP\-Proxy unter Unix anzugeben sieht beispielsweise so aus:
-
-  export http_proxy="http://proxy.example.com:8080"
-
+\fBexport http_proxy="http://proxy.example.com:8080"\fP
+.TP 
 Proxy\-Authentifizierung wird ebenfalls unterstützt:
-
-  export http_proxy="http://user1:mypass@proxy.example.org:8081"
-
+\fBexport http_proxy="http://user1:mypass@proxy.example.org:8081"\fP
+.TP 
 Setzen eines Proxies unter der Windows Befehlszeile:
-
-  set http_proxy=http://proxy.example.com:8080
-
+\fBset http_proxy=http://proxy.example.com:8080\fP
 .SH "Durchgeführte Prüfungen"
 Alle URLs müssen einen ersten Syntaxtest bestehen. Kleine Kodierungsfehler
 ergeben eine Warnung, jede andere ungültige Syntaxfehler sind Fehler. Nach
 dem Bestehen des Syntaxtests wird die URL in die Schlange zum
 Verbindungstest gestellt. Alle Verbindungstests sind weiter unten
 beschrieben.
-.
 .TP 
 HTTP Verknüpfungen (\fBhttp:\fP, \fBhttps:\fP)
 After connecting to the given HTTP server the given path or query is
 requested. All redirections are followed, and if user/password is given it
 will be used as authorization when necessary.  All final HTTP status codes
 other than 2xx are errors.
-.
+.IP
 Der Inhalt von HTML\-Seiten wird rekursiv geprüft.
 .TP 
 Lokale Dateien (\fBfile:\fP)
@@ -337,57 +334,64 @@ Eine reguläre, lesbare Datei die geöffnet werden kann ist gültig. Ein
 lesbares Verzeichnis ist ebenfalls gültig. Alle anderen Dateien, zum
 Beispiel Gerätedateien, unlesbare oder nicht existente Dateien ergeben einen
 Fehler.
-.
+.IP
 HTML\- oder andere untersuchbare Dateiinhalte werden rekursiv geprüft.
 .TP 
 Mail\-Links (\fBmailto:\fP)
 Ein mailto:\-Link ergibt eine Liste von E\-Mail\-Adressen. Falls eine Adresse
 fehlerhaft ist, wird die ganze Liste als fehlerhaft angesehen. Für jede
 E\-Mail\-Adresse werden die folgenden Dinge geprüft:
-.
-  1) Prüfe die Syntax der Adresse, sowohl den Teil vor als auch nach dem @\-Zeichen.
-  2) Schlage den MX DNS\-Datensatz nach. Falls kein MX Datensatz gefunden wurde, wird ein Fehler ausgegeben.
-  3) Prüfe, ob einer der Mail\-Rechner eine SMTP\-Verbindung akzeptiert.
-     Rechner mit höherer Priorität werden zuerst geprüft.
-     Fall kein Rechner SMTP\-Verbindungen akzeptiert, wird eine Warnung ausgegeben.
-  4) Versuche, die Adresse mit dem VRFY\-Befehl zu verifizieren. Falls eine Antwort kommt, wird die verifizierte Adresse als Information ausgegeben.
+.br
+1) Check the adress syntax, both of the part before and after the @ sign.
+.br
+2) Look up the MX DNS records. If we found no MX record, print an error.
+.br
+3) Check if one of the mail hosts accept an SMTP connection.  Check hosts
+with higher priority first.  If no host accepts SMTP, we print a warning.
+.br
+4) Try to verify the address with the VRFY command. If we got an answer,
+print the verified address as an info.
+
 .TP 
 FTP\-Links (\fBftp:\fP)
-  
-Für FTP\-Links wird Folgendes geprüft:
-  
-  1) Eine Verbindung zum angegeben Rechner wird aufgebaut
-  2) Versuche, sich mit dem gegebenen Nutzer und Passwort anzumelden. Der Standardbenutzer ist \*(lqanonymous\*(lq, das Standardpasswort ist \*(lqanonymous@\*(lq.
-  3) Versuche, in das angegebene Verzeichnis zu wechseln
-  4) Liste die Dateien im Verzeichnis auf mit dem NLST\-Befehl
+For FTP links we do:
+.br
+1) connect to the specified host
+.br
+2) try to login with the given user and password. The default user is
+\fBanonymous\fP, the default password is \fBanonymous@\fP.
+.br
+3) try to change to the given directory
+.br
+4) list the file with the NLST command
 
 .TP 
-Telnet\-Links (\*(lqtelnet:\*(lq)
-  
-  Versuche, zu dem angegeben Telnetrechner zu verginden und falls Benutzer/Passwort angegeben sind, wird versucht, sich anzumelden.
+Telnet links (\fBtelnet:\fP)
+We try to connect and if user/password are given, login to the given telnet
+server.
 
 .TP 
-NNTP\-Links (\*(lqnews:\*(lq, \*(lqsnews:\*(lq, \*(lqnntp\*(lq)
-  
-  Versuche, zu dem angegebenen NNTP\-Rechner eine Verbindung aufzubaucne. Falls eine Nachrichtengruppe oder ein bestimmter Artikel angegeben ist, wird versucht, diese Gruppe oder diesen Artikel vom Rechner anzufragen.
+NNTP links (\fBnews:\fP, \fBsnews:\fP, \fBnntp\fP)
+We try to connect to the given NNTP server. If a news group or article is
+specified, try to request it from the server.
 
 .TP 
-Nicht unterstützte Links (\*(lqjavascript:\*(lq, etc.)
-  
-  Ein nicht unterstützter Link wird nur eine Warnung ausgeben. Weitere Prüfungen werden nicht durchgeführt.
-  
-  Die komplette Liste von erkannten, aber nicht unterstützten Links ist in der
-  Quelldatei \fBlinkcheck/checker/unknownurl.py\fP. Die bekanntesten davon dürften JavaScript\-Links sein.
-
+Unsupported links (\fBjavascript:\fP, etc.)
+An unsupported link will only print a warning. No further checking will be
+made.
+.IP
+The complete list of recognized, but unsupported links can be found in the
+.UR https://github.com/linkchecker/linkchecker/blob/master/linkcheck/checker/unknownurl.py
+linkcheck/checker/unknownurl.py
+.UE
+source file.  The most prominent of
+them should be JavaScript links.
 .SH PLUGINS
-There are two plugin types: connection and content plugins.
-.
-Connection plugins are run after a successful connection to the URL host.
-.
-Content plugins are run if the URL type has content (mailto: URLs have no
-content for example) and if the check is not forbidden (ie. by HTTP
-robots.txt).
-.
+There are two plugin types: connection and content plugins.  Connection
+plugins are run after a successful connection to the URL host.  Content
+plugins are run if the URL type has content (mailto: URLs have no content
+for example) and if the check is not forbidden (ie. by HTTP robots.txt).
+.PP
 See \fBlinkchecker \-\-list\-plugins\fP for a list of plugins and their
 documentation. All plugins are enabled via the \fBlinkcheckerrc\fP(5)
 configuration file.
@@ -446,11 +450,11 @@ Proxy\-Server kontaktiert werden
 .
 .SH RÜCKGABEWERT
 Der Rückgabewert ist 2 falls
-.IP \(bu
+.IP \(bu 2
 ein Programmfehler aufgetreten ist.
 .PP
 Der Rückgabewert ist 1 falls
-.IP \(bu
+.IP \(bu 2
 ungültige Verknüpfungen gefunden wurden oder
 .IP \(bu
 Warnungen gefunden wurden und Warnungen aktiviert sind
@@ -471,11 +475,14 @@ Ausgabe
 .br
 \fBlinkchecker\-out.\fP\fITYP\fP \- Standard Dateiname der Logausgabe
 .br
-\fBhttp://docs.python.org/library/codecs.html#standard\-encodings\fP \- gültige
-Ausgabe Enkodierungen
+.UR https://docs.python.org/library/codecs.html#standard\-encodings
+.UE
+\- valid output encodings
 .br
-\fBhttp://docs.python.org/howto/regex.html\fP \- Dokumentation zu regulären
-Ausdrücken
+.UR https://docs.python.org/howto/regex.html
+.UE
+\- regular expression
+documentation
 
 .SH "SIEHE AUCH"
 \fBlinkcheckerrc\fP(5)

--- a/doc/de/linkchecker.1
+++ b/doc/de/linkchecker.1
@@ -50,19 +50,19 @@ Rekursionstiefe zu beschränken.
 Don't check URLs with \fB/secret\fP in its name. All other links are checked as usual:
 \fBlinkchecker \-\-ignore\-url=/secret mysite.example.com\fP
 .TP 
-Checking a local HTML file on Unix:
+Überprüfung einer lokalen HTML Datei unter Unix:
 \fBlinkchecker ../bla.html\fP
 .TP 
-Checking a local HTML file on Windows:
+Überprüfung einer lokalen HTML Datei unter Windows:
 \fBlinkchecker c:\temp\test.html\fP
 .TP 
-You can skip the \fBhttp://\fP url part if the domain starts with \fBwww.\fP:
+Sie können den \fBhttp://\fP URL Anteil weglassen wenn die Domäne mit \fBwww.\fP beginnt:
 \fBlinkchecker www.example.com\fP
 .TP 
-You can skip the \fBftp://\fP url part if the domain starts with \fBftp.\fP:
+Sie können den \fBftp://\fP URL Anteil weglassen wenn die Domäne mit \fBftp.\fP
 \fBlinkchecker \-r0 ftp.example.com\fP
 .TP 
-Generate a sitemap graph and convert it with the graphviz dot utility:
+Erzeuge einen Sitemap Graphen und konvertiere ihn mit dem graphviz dot Programm:
 \fBlinkchecker \-odot \-v www.example.com | dot \-Tps > sitemap.ps\fP
 .SH OPTIONEN
 .SS "Allgemeine Optionen"
@@ -79,8 +79,9 @@ Lese Liste von URLs zum Prüfen von der Standardeingabe, getrennt durch
 Leerzeichen.
 .TP 
 \fB\-t\fP\fINUMMER\fP, \fB\-\-threads=\fP\fINUMMER\fP
-Generate no more than the given number of threads. Default number of threads
-is 10. To disable threading specify a non\-positive number.
+Generiere nicht mehr als die angegebene Anzahl von Threads. Die
+Standardanzahl von Threads ist 10. Um Threads zu deaktivieren, geben Sie
+eine nicht positive Nummer an.
 .TP 
 \fB\-V\fP, \fB\-\-version\fP
 Gebe die Version aus und beende das Programm.
@@ -91,17 +92,18 @@ Print available check plugins and exit.
 .SS Ausgabeoptionen
 .TP 
 \fB\-D\fP\fINAME\fP, \fB\-\-debug=\fP\fINAME\fP
-Print debugging output for the given logger.  Available loggers are
-\fBcmdline\fP, \fBchecking\fP, \fBcache\fP, \fBdns\fP, \fBplugin\fP and \fBall\fP.  Specifying
-\fBall\fP is an alias for specifying all available loggers.  The option can be
-given multiple times to debug with more than one logger.  For accurate
-results, threading will be disabled during debug runs.
+Gebe Testmeldungen aus für den angegebenen Logger. Verfügbare Logger sind
+\fBcmdline\fP, \fBchecking\fP,\fBcache\fP, \fBdns\fP, \fBplugins\fP und \fBall\fP. Die Angabe
+\fBall\fP ist ein Synonym für alle verfügbaren Logger. Diese Option kann
+mehrmals angegeben werden, um mit mehr als einem Logger zu testen. Um
+akkurate Ergebnisse zu erzielen, werden Threads deaktiviert.
 .TP 
 \fB\-F\fP\fITYP\fP[\fB/\fP\fIENKODIERUNG\fP][\fB/\fP\fIDATEINAME\fP], \fB\-\-file\-output=\fP\fITYP\fP[\fB/\fP\fIENKODIERUNG\fP][\fB/\fP\fIDATEINAME\fP]
-Output to a file \fBlinkchecker\-out.\fP\fITYPE\fP, \fB$HOME/.linkchecker/blacklist\fP
-for \fBblacklist\fP output, or \fIFILENAME\fP if specified.  The \fIENCODING\fP
-specifies the output encoding, the default is that of your locale.  Valid
-encodings are listed at
+Ausgabe in eine Datei namens \fBlinkchecker\-out.\fP\fITYP\fP,
+\fB$HOME/.linkchecker/blacklist\fP bei \fBblacklist\fP Ausgabe, oder \fIDATEINAME\fP
+falls angegeben. Das \fIENCODING\fP gibt die Ausgabekodierung an. Der Standard
+ist das der lokalen Spracheinstellung. Gültige Enkodierungen sind
+aufgelistet unter
 .UR https://docs.python.org/library/codecs.html#standard\-encodings
 .UE .
 .br
@@ -125,8 +127,8 @@ Gib Ausgabetyp als \fBtext\fP, \fBhtml\fP, \fBsql\fP, \fBcsv\fP, \fBgml\fP, \fBd
 \fBsitemap\fP, \fBnone\fP oder \fBblacklist\fP an.  Stadard Typ ist \fBtext\fP. Die
 verschiedenen Ausgabetypen sind unten dokumentiert.
 .br
-The \fIENCODING\fP specifies the output encoding, the default is that of your
-locale. Valid encodings are listed at
+Das \fIENCODING\fP gibt die Ausgabekodierung an. Der Standard ist das der
+lokalen Spracheinstellung. Gültige Enkodierungen sind aufgelistet unter
 .UR https://docs.python.org/library/codecs.html#standard\-encodings
 .UE .
 .TP 
@@ -206,9 +208,9 @@ z.B. "Mozilla/4.0". Der Standard ist "LinkChecker/X.Y", wobei X.Y die
 aktuelle Version von LinkChecker ist.
 
 .SH KONFIGURATIONSDATEIEN
-Configuration files can specify all options above. They can also specify
-some options that cannot be set on the command line.  See
-\fBlinkcheckerrc\fP(5)  for more info.
+Konfigurationsdateien können alle obigen Optionen enthalten. Sie können
+zudem Optionen enthalten, welche nicht auf der Kommandozeile gesetzt werden
+können. Siehe \fBlinkcheckerrc\fP(5) für mehr Informationen.
 
 .SH AUSGABETYPEN
 Beachten Sie, dass standardmäßig nur Fehler und Warnungen protokolliert
@@ -240,9 +242,10 @@ Gebe Prüfresultat als GraphXML\-Datei aus.
 Gebe Prüfresultat als maschinenlesbare XML\-Datei aus.
 .TP 
 \fBsitemap\fP
-Log check result as an XML sitemap whose protocol is documented at
+Protokolliere Prüfergebnisse als XML Sitemap dessen Format unter
 .UR https://www.sitemaps.org/protocol.html
 .UE .
+dokumentiert ist.
 .TP 
 \fBsql\fP
 Gebe Prüfresultat als SQL Skript mit INSERT Befehlen aus. Ein
@@ -258,10 +261,10 @@ und die Anzahl der Fehlversuche enthält.
 Gibt nichts aus. Für Debugging oder Prüfen des Rückgabewerts geeignet.
 .
 .SH "REGULÄRE AUSDRÜCKE"
-LinkChecker accepts Python regular expressions.  See
+LinkChecker akzeptiert Pythons reguläre Ausdrücke. Siehe
 .UR https://docs.python.org/howto/regex.html
 .UE
-for an introduction.
+für eine Einführung.
 
 Eine Ergänzung ist, dass ein regulärer Ausdruck negiert wird falls er mit
 einem Ausrufezeichen beginnt.
@@ -277,7 +280,7 @@ Setzt die Domäne für die die Cookies gültig sind.
 \fBPath\fP (optional)
 Gibt den Pfad für den die Cookies gültig sind; Standardpfad ist \fB/\fP.
 .TP 
-\fBSet\-cookie\fP (required)
+\fBSet\-cookie\fP (erforderlich)
 Setzt den Cookie Name/Wert. Kann mehrmals angegeben werden.
 .PP
 Mehrere Einträge sind durch eine Leerzeile zu trennen.
@@ -286,21 +289,21 @@ Das untige Beispiel sendet zwei Cookies zu allen URLs die mit
 \fBhttp://example.org/hello/\fP beginnen, und eins zu allen URLs die mit
 \fBhttps://example.org\fP beginnen:
 .EX
-  Host: example.com
-  Path: /hello
-  Set\-cookie: ID="smee"
-  Set\-cookie: spam="egg"
+ Host: example.com
+ Path: /hello
+ Set\-cookie: ID="smee"
+ Set\-cookie: spam="egg"
 .PP
   Host: example.org
   Set\-cookie: baggage="elitist"; comment="hologram"
 .EE
 .SH "PROXY UNTERSTÜTZUNG"
-To use a proxy on Unix or Windows set the $http_proxy, $https_proxy or
-$ftp_proxy environment variables to the proxy URL. The URL should be of the
-form \fBhttp://\fP[\fIuser\fP\fB:\fP\fIpass\fP\fB@\fP]\fIhost\fP[\fB:\fP\fIport\fP].  LinkChecker
-also detects manual proxy settings of Internet Explorer under Windows
-systems, and gconf or KDE on Linux systems.  On a Mac use the Internet
-Config to select a proxy.
+Um einen Proxy unter Unix oder Windows zu benutzen, setzen Sie die
+$http_proxy, $https_proxy oder $ftp_proxy Umgebungsvariablen auf die Proxy
+URL. Die URL sollte die Form
+\fBhttp://\fP[\fIuser\fP\fB:\fP\fIpass\fP\fB@\fP]\fIhost\fP[\fB:\fP\fIport\fP] besitzen. LinkChecker
+erkennt auch die Proxy\-Einstellungen des Internet Explorers auf einem
+Windows\-System. Auf einem Mac benutzen Sie die Internet Konfiguration.
 .PP
 Sie können eine komma\-separierte Liste von Domainnamen in der $no_proxy
 Umgebungsvariable setzen, um alle Proxies für diese Domainnamen zu
@@ -356,29 +359,30 @@ print the verified address as an info.
 FTP\-Links (\fBftp:\fP)
 For FTP links we do:
 .br
-1) connect to the specified host
+1) Eine Verbindung zum angegeben Rechner wird aufgebaut
 .br
-2) try to login with the given user and password. The default user is
-\fBanonymous\fP, the default password is \fBanonymous@\fP.
+2) Versuche, sich mit dem gegebenen Nutzer und Passwort anzumelden. Der
+Standardbenutzer ist \*(lqanonymous\*(lq, das Standardpasswort ist \*(lqanonymous@\*(lq.
 .br
-3) try to change to the given directory
+3) Versuche, in das angegebene Verzeichnis zu wechseln
 .br
-4) list the file with the NLST command
+4) Liste die Dateien im Verzeichnis auf mit dem NLST\-Befehl
 
 .TP 
 Telnet links (\fBtelnet:\fP)
-We try to connect and if user/password are given, login to the given telnet
-server.
+Versuche, zu dem angegeben Telnetrechner zu verginden und falls
+Benutzer/Passwort angegeben sind, wird versucht, sich anzumelden.
 
 .TP 
 NNTP links (\fBnews:\fP, \fBsnews:\fP, \fBnntp\fP)
-We try to connect to the given NNTP server. If a news group or article is
-specified, try to request it from the server.
+Versuche, zu dem angegebenen NNTP\-Rechner eine Verbindung aufzubaucne. Falls
+eine Nachrichtengruppe oder ein bestimmter Artikel angegeben ist, wird
+versucht, diese Gruppe oder diesen Artikel vom Rechner anzufragen.
 
 .TP 
-Unsupported links (\fBjavascript:\fP, etc.)
-An unsupported link will only print a warning. No further checking will be
-made.
+Nicht unterstützte Links (\fBjavascript:\fP, etc.)
+Ein nicht unterstützter Link wird nur eine Warnung ausgeben. Weitere
+Prüfungen werden nicht durchgeführt.
 .IP
 The complete list of recognized, but unsupported links can be found in the
 .UR https://github.com/linkchecker/linkchecker/blob/master/linkcheck/checker/unknownurl.py
@@ -477,12 +481,12 @@ Ausgabe
 .br
 .UR https://docs.python.org/library/codecs.html#standard\-encodings
 .UE
-\- valid output encodings
+\- gültige Ausgabe Enkodierungen
 .br
 .UR https://docs.python.org/howto/regex.html
 .UE
-\- regular expression
-documentation
+\- Dokumentation zu
+regulären Ausdrücken
 
 .SH "SIEHE AUCH"
 \fBlinkcheckerrc\fP(5)

--- a/doc/de/linkcheckerrc.5
+++ b/doc/de/linkcheckerrc.5
@@ -17,8 +17,8 @@ Die Standarddatei ist \fB~/.linkchecker/linkcheckerrc\fP unter Unix\-,
 .SS [checking]
 .TP 
 \fBcookiefile=\fP\fIDateiname\fP
-Read a file with initial cookie data. The cookie data format is explained in
-\fBlinkchecker\fP(1).
+Lese eine Datei mit Cookie\-Daten. Das Cookie Datenformat wird in
+\fBlinkchecker\fP(1) erklärt.
 .br
 Kommandozeilenoption: \fB\-\-cookiefile\fP
 .TP 
@@ -47,8 +47,9 @@ bewirkt unendliche Rekursion. Standard Tiefe ist unendlich.
 Kommandozeilenoption: \fB\-\-recursion\-level\fP
 .TP 
 \fBthreads=\fP\fINUMBER\fP
-Generate no more than the given number of threads. Default number of threads
-is 10. To disable threading specify a non\-positive number.
+Generiere nicht mehr als die angegebene Anzahl von Threads. Die
+Standardanzahl von Threads ist 10. Um Threads zu deaktivieren, geben Sie
+eine nicht positive Nummer an.
 .br
 Kommandozeilenoption: \fB\-\-threads\fP
 .TP 
@@ -58,7 +59,7 @@ Setze den Timeout für TCP\-Verbindungen in Sekunden. Der Standard Timeout ist
 .br
 Kommandozeilenoption: \fB\-\-timeout\fP
 .TP 
-\fBaborttimeout=\fP\fINUMBER\fP
+\fBaborttimeout=\fP\fINUMMER\fP
 Time to wait for checks to finish after the user aborts the first time (with
 Ctrl\-C or the abort button).  The default abort timeout is 300 seconds.
 .br
@@ -96,7 +97,7 @@ Standard ist alle URLs anzunehmen und zu prüfen.
 .br
 Kommandozeilenoption: keine
 .TP 
-\fBmaxrequestspersecond=\fP\fINUMBER\fP
+\fBmaxrequestspersecond=\fP\fINUMMER\fP
 Limit the maximum number of requests per second to one host.
 .TP 
 \fBallowedschemes=\fP\fINAME\fP[\fB,\fP\fINAME\fP...]
@@ -130,7 +131,7 @@ Kommandozeilenoption: \fB\-\-no\-follow\-url\fP
 \fBcheckextern=\fP[\fB0\fP|\fB1\fP]
 Check external links. Default is to check internal links only.
 .br
-Command line option: \fB\-\-checkextern\fP
+Kommandozeilenoption: \fB\-\-checkextern\fP
 .SS [authentication]
 .TP 
 \fBentry=\fP\fIREGEX\fP \fIBENUTZER\fP [\fIPASSWORT\fP] (MULTILINE)
@@ -188,8 +189,8 @@ Gib Ausgabetyp als \fBtext\fP, \fBhtml\fP, \fBsql\fP, \fBcsv\fP, \fBgml\fP, \fBd
 \fBnone\fP oder \fBblacklist\fP an.  Stadard Typ ist \fBtext\fP. Die verschiedenen
 Ausgabetypen sind unten dokumentiert.
 .br
-The \fIENCODING\fP specifies the output encoding, the default is that of your
-locale. Valid encodings are listed at
+Das \fIENCODING\fP gibt die Ausgabekodierung an. Der Standard ist das der
+lokalen Spracheinstellung. Gültige Enkodierungen sind aufgelistet unter
 .UR https://docs.python.org/library/codecs.html#standard\-encodings
 .UE .
 .br
@@ -232,7 +233,7 @@ Kommagetrennte Liste von Teilen, die ausgegeben werden sollen. Siehe
 Kommandozeilenoption: keine
 .TP 
 \fBencoding=\fP\fISTRING\fP
-Valid encodings are listed in
+Gültige Enkodierungen sind aufgelistet unter
 .UR https://docs.python.org/library/codecs.html#standard\-encodings
 .UE .
 .br
@@ -330,7 +331,7 @@ Siehe [text] Sektion weiter oben.
 Setze Datenbankname zum Speichern. Standard ist \fBlinksdb\fP.
 .TP 
 \fBseparator=\fP\fICHAR\fP
-Set SQL command separator character. Default is a semicolon (\fB;\fP).
+Setze SQL Kommandotrennzeichen. Standard ist ein Strichpunkt (\fB;\fP).
 .SS [html]
 .TP 
 \fBfilename=\fP\fISTRING\fP
@@ -405,7 +406,7 @@ Eine Nummer zwischen 0.0 und 1.0, welche die Priorität festlegt. Die
 Standardpriorität für die erste URL ist 1.0, für alle Kind\-URLs ist sie 0.5.
 .TP 
 \fBfrequency=\fP[\fBalways\fP|\fBhourly\fP|\fBdaily\fP|\fBweekly\fP|\fBmonthly\fP|\fByearly\fP|\fBnever\fP]
-How frequently pages are changing.
+Die Häufigkeit mit der Seiten sich ändern.
 .
 .SH "AUSGABE PARTS"
 .TS

--- a/doc/de/linkcheckerrc.5
+++ b/doc/de/linkcheckerrc.5
@@ -3,7 +3,7 @@
 .\" This file was generated with po4a. Translate the source file.
 .\"
 .\"*******************************************************************
-.TH linkcheckerrc 5 2007\-11\-30 LinkChecker 
+.TH LINKCHECKERRC 5 2020\-04\-24 LinkChecker "LinkChecker User Manual"
 .SH NAME
 linkcheckerrc \- Konfigurationsdatei für LinkChecker
 .
@@ -17,8 +17,8 @@ Die Standarddatei ist \fB~/.linkchecker/linkcheckerrc\fP unter Unix\-,
 .SS [checking]
 .TP 
 \fBcookiefile=\fP\fIDateiname\fP
-Lese eine Datei mit Cookie\-Daten. Das Cookie Datenformat wird in
-linkchecker(1) erklärt.
+Read a file with initial cookie data. The cookie data format is explained in
+\fBlinkchecker\fP(1).
 .br
 Kommandozeilenoption: \fB\-\-cookiefile\fP
 .TP 
@@ -188,9 +188,10 @@ Gib Ausgabetyp als \fBtext\fP, \fBhtml\fP, \fBsql\fP, \fBcsv\fP, \fBgml\fP, \fBd
 \fBnone\fP oder \fBblacklist\fP an.  Stadard Typ ist \fBtext\fP. Die verschiedenen
 Ausgabetypen sind unten dokumentiert.
 .br
-Das \fIENCODING\fP gibt die Ausgabekodierung an. Der Standard ist das der
-lokalen Spracheinstellung. Gültige Enkodierungen sind aufgelistet unter
-\fBhttp://docs.python.org/library/codecs.html#standard\-encodings\fP.
+The \fIENCODING\fP specifies the output encoding, the default is that of your
+locale. Valid encodings are listed at
+.UR https://docs.python.org/library/codecs.html#standard\-encodings
+.UE .
 .br
 Kommandozeilenoption: \fB\-\-output\fP
 .TP 
@@ -231,8 +232,9 @@ Kommagetrennte Liste von Teilen, die ausgegeben werden sollen. Siehe
 Kommandozeilenoption: keine
 .TP 
 \fBencoding=\fP\fISTRING\fP
-Gültige Enkodierungen sind aufgelistet unter
-\fBhttp://docs.python.org/library/codecs.html#standard\-encodings\fP.
+Valid encodings are listed in
+.UR https://docs.python.org/library/codecs.html#standard\-encodings
+.UE .
 .br
 Die Standardenkodierung ist \fBiso\-8859\-15\fP.
 .TP 
@@ -406,41 +408,47 @@ Standardpriorität für die erste URL ist 1.0, für alle Kind\-URLs ist sie 0.5.
 How frequently pages are changing.
 .
 .SH "AUSGABE PARTS"
- \fBall\fP       (für alle Teile)
- \fBid\fP        (eine eindeutige ID für jeden Logeintrag)
- \fBrealurl\fP   (die volle URL Verknüpfung)
- \fBresult\fP    (gültig oder ungültig, mit Nachrichten)
- \fBextern\fP    (1 oder 0, nur in einigen Ausgabetypen protokolliert)
- \fBbase\fP      (base href=...)
- \fBname\fP      (<a href=...>name</a> and <img alt="name">)
- \fBparenturl\fP (falls vorhanden)
- \fBinfo\fP      (einige zusätzliche Infos, z.B. FTP Willkommensnachrichten)
- \fBwarning\fP   (Warnungen)
- \fBdltime\fP    (Downloadzeit)
- \fBchecktime\fP (Prüfzeit)
- \fBurl\fP       (Der Original URL Name, kann relativ sein)
- \fBintro\fP     (Das Zeug am Anfang, "Beginne am ...")
- \fBoutro\fP     (Das Zeug am Ende, "X Fehler gefunden ...")
+.TS
+nokeep, tab(@);
+ll.
+\fBall\fP@(for all parts)
+\fBid\fP@(a unique ID for each logentry)
+\fBrealurl\fP@(the full url link)
+\fBresult\fP@(valid or invalid, with messages)
+\fBextern\fP@(1 or 0, only in some logger types reported)
+\fBbase\fP@(base href=...)
+\fBname\fP@(<a href=...>name</a> and <img alt="name">)
+\fBparenturl\fP@(if any)
+\fBinfo\fP@(some additional info, e.g. FTP welcome messages)
+\fBwarning\fP@(warnings)
+\fBdltime\fP@(download time)
+\fBchecktime\fP@(check time)
+\fBurl\fP@(the original url name, can be relative)
+\fBintro\fP@(the blurb at the beginning, "starting at ...")
+\fBoutro\fP@(the blurb at the end, "found x errors ...")
+.TE
 .SH MULTILINE
 Einige Optionen können mehrere Zeilen lang sein. Jede Zeile muss dafür
 eingerückt werden. Zeilen die mit einer Raute (\fB#\fP) beginnen werden
 ignoriert, müssen aber eingerückt sein.
-
- ignore=
-   lconline
-   bookmark
-   # a comment   ^mailto:
-.
+.EX
+ignore=
+  lconline
+  bookmark
+  # a comment
+  ^mailto:
+.EE
 .SH BEISPIEL
- [output]
- log=html
-
- [checking]
- threads=5
-
- [filtering]
- ignorewarnings=http\-moved\-permanent
-
+.EX
+[output]
+log=html
+.PP
+[checking]
+threads=5
+.PP
+[filtering]
+ignorewarnings=http\-moved\-permanent
+.EE
 .SH PLUGINS
 All plugins have a separate section. If the section appears in the
 configuration file the plugin is enabled.  Some plugins read extra options
@@ -476,7 +484,8 @@ Configures the expiration warning time in days.
 
 .SS [HtmlSyntaxCheck]
 Check the syntax of HTML pages with the online W3C HTML validator.  See
-http://validator.w3.org/docs/api.html.
+.UR https://validator.w3.org/docs/api.html
+.UE .
 
 .SS [HttpHeaderInfo]
 Print HTTP headers in URL info.
@@ -487,7 +496,8 @@ headers that start with "X\-".
 
 .SS [CssSyntaxCheck]
 Check the syntax of HTML pages with the online W3C CSS validator.  See
-http://jigsaw.w3.org/css\-validator/manual.html#expert.
+.UR https://jigsaw.w3.org/css\-validator/manual.html#expert
+.UE .
 
 .SS [VirusCheck]
 Checks the page content for virus infections with clamav.  A local clamav
@@ -552,7 +562,7 @@ Die IP\-Adresse ist verschleiert.
 Die URL %(url)s enthält Leerzeichen am Anfang oder Ende.
 
 .SH "SIEHE AUCH"
-BEISPIEL
+\fBlinkchecker\fP(1)
 .
 .SH AUTHOR
 Bastian Kleineidam <bastian.kleineidam@web.de>

--- a/doc/linkchecker.doc.pot
+++ b/doc/linkchecker.doc.pot
@@ -7,13 +7,13 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-01-21 12:56+0100\n"
+"POT-Creation-Date: 2020-06-04 17:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: TH
@@ -23,9 +23,9 @@ msgid "LINKCHECKER"
 msgstr ""
 
 #. type: TH
-#: en/linkchecker.1:1
+#: en/linkchecker.1:1 en/linkcheckerrc.5:1
 #, no-wrap
-msgid "2010-07-01"
+msgid "2020-04-24"
 msgstr ""
 
 #. type: TH
@@ -35,9 +35,9 @@ msgid "LinkChecker"
 msgstr ""
 
 #. type: TH
-#: en/linkchecker.1:1
+#: en/linkchecker.1:1 en/linkcheckerrc.5:1
 #, no-wrap
-msgid "LinkChecker commandline usage"
+msgid "LinkChecker User Manual"
 msgstr ""
 
 #. type: SH
@@ -54,13 +54,13 @@ msgid ""
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:5
+#: en/linkchecker.1:4
 #, no-wrap
 msgid "SYNOPSIS"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:7
+#: en/linkchecker.1:8
 msgid "B<linkchecker> [I<options>] [I<file-or-url>]..."
 msgstr ""
 
@@ -70,13 +70,18 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#. type: Plain text
-#: en/linkchecker.1:11
+#. type: TP
+#: en/linkchecker.1:9
+#, no-wrap
 msgid "LinkChecker features"
 msgstr ""
 
 #. type: IP
-#: en/linkchecker.1:11 en/linkchecker.1:13 en/linkchecker.1:15 en/linkchecker.1:17 en/linkchecker.1:19 en/linkchecker.1:21 en/linkchecker.1:23 en/linkchecker.1:25 en/linkchecker.1:27 en/linkchecker.1:29 en/linkchecker.1:31 en/linkchecker.1:33 en/linkchecker.1:458 en/linkchecker.1:462 en/linkchecker.1:464
+#: en/linkchecker.1:11 en/linkchecker.1:13 en/linkchecker.1:15
+#: en/linkchecker.1:17 en/linkchecker.1:19 en/linkchecker.1:21
+#: en/linkchecker.1:23 en/linkchecker.1:25 en/linkchecker.1:27
+#: en/linkchecker.1:29 en/linkchecker.1:31 en/linkchecker.1:33
+#: en/linkchecker.1:467 en/linkchecker.1:471 en/linkchecker.1:473
 #, no-wrap
 msgid "\\(bu"
 msgstr ""
@@ -151,68 +156,90 @@ msgstr ""
 msgid "EXAMPLES"
 msgstr ""
 
-#. type: Plain text
-#: en/linkchecker.1:38
+#. type: TP
+#: en/linkchecker.1:36
 #, no-wrap
-msgid ""
-"The most common use checks the given domain recursively:\n"
-"  B<linkchecker http://www.example.com/>\n"
+msgid "The most common use checks the given domain recursively:"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:41
+#: en/linkchecker.1:39
+msgid "B<linkchecker http://www.example.com/>"
+msgstr ""
+
+#. type: Plain text
+#: en/linkchecker.1:42
 msgid ""
 "Beware that this checks the whole site which can have thousands of URLs.  "
 "Use the B<-r> option to restrict the recursion depth."
 msgstr ""
 
-#. type: Plain text
-#: en/linkchecker.1:44
+#. type: TP
+#: en/linkchecker.1:42
 #, no-wrap
 msgid ""
 "Don't check URLs with B</secret> in its name. All other links are checked as "
-"usual:\n"
-"  B<linkchecker --ignore-url=/secret mysite.example.com>\n"
+"usual:"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:47
+#: en/linkchecker.1:45
+msgid "B<linkchecker --ignore-url=/secret mysite.example.com>"
+msgstr ""
+
+#. type: TP
+#: en/linkchecker.1:45
 #, no-wrap
-msgid ""
-"Checking a local HTML file on Unix:\n"
-"  B<linkchecker ../bla.html>\n"
+msgid "Checking a local HTML file on Unix:"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:50
+#: en/linkchecker.1:48
+msgid "B<linkchecker ../bla.html>"
+msgstr ""
+
+#. type: TP
+#: en/linkchecker.1:48
 #, no-wrap
-msgid ""
-"Checking a local HTML file on Windows:\n"
-"  B<linkchecker c:\\etemp\\etest.html>\n"
+msgid "Checking a local HTML file on Windows:"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:53
+#: en/linkchecker.1:51
+msgid "B<linkchecker c:\\temp\\test.html>"
+msgstr ""
+
+#. type: TP
+#: en/linkchecker.1:51
 #, no-wrap
-msgid ""
-"You can skip the B<http://> url part if the domain starts with B<www.>:\n"
-"  B<linkchecker www.example.com>\n"
+msgid "You can skip the B<http://> url part if the domain starts with B<www.>:"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:56
+#: en/linkchecker.1:54
+msgid "B<linkchecker www.example.com>"
+msgstr ""
+
+#. type: TP
+#: en/linkchecker.1:54
 #, no-wrap
-msgid ""
-"You can skip the B<ftp://> url part if the domain starts with B<ftp.>:\n"
-"  B<linkchecker -r0 ftp.example.com>\n"
+msgid "You can skip the B<ftp://> url part if the domain starts with B<ftp.>:"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:59
+#: en/linkchecker.1:57
+msgid "B<linkchecker -r0 ftp.example.com>"
+msgstr ""
+
+#. type: TP
+#: en/linkchecker.1:57
 #, no-wrap
-msgid ""
-"Generate a sitemap graph and convert it with the graphviz dot utility:\n"
-"  B<linkchecker -odot -v www.example.com | dot -Tps E<gt> sitemap.ps>\n"
+msgid "Generate a sitemap graph and convert it with the graphviz dot utility:"
+msgstr ""
+
+#. type: Plain text
+#: en/linkchecker.1:60
+msgid "B<linkchecker -odot -v www.example.com | dot -Tps E<gt> sitemap.ps>"
 msgstr ""
 
 #. type: SH
@@ -269,7 +296,7 @@ msgid "B<-t>I<NUMBER>, B<--threads=>I<NUMBER>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:76 en/linkcheckerrc.5:47
+#: en/linkchecker.1:76 en/linkcheckerrc.5:48
 msgid ""
 "Generate no more than the given number of threads. Default number of threads "
 "is 10. To disable threading specify a non-positive number."
@@ -313,10 +340,10 @@ msgstr ""
 #: en/linkchecker.1:94
 msgid ""
 "Print debugging output for the given logger.  Available loggers are "
-"B<cmdline>, B<checking>, B<cache>, B<dns>, B<plugins> and B<all>.  "
-"Specifying B<all> is an alias for specifying all available loggers.  The "
-"option can be given multiple times to debug with more than one logger.  For "
-"accurate results, threading will be disabled during debug runs."
+"B<cmdline>, B<checking>, B<cache>, B<dns>, B<plugin> and B<all>.  Specifying "
+"B<all> is an alias for specifying all available loggers.  The option can be "
+"given multiple times to debug with more than one logger.  For accurate "
+"results, threading will be disabled during debug runs."
 msgstr ""
 
 #. type: TP
@@ -328,17 +355,17 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:103
+#: en/linkchecker.1:104
 msgid ""
 "Output to a file B<linkchecker-out.>I<TYPE>, B<$HOME/.linkchecker/blacklist> "
 "for B<blacklist> output, or I<FILENAME> if specified.  The I<ENCODING> "
 "specifies the output encoding, the default is that of your locale.  Valid "
-"encodings are listed at "
-"B<http://docs.python.org/library/\\:codecs.html#standard-encodings>."
+"encodings are listed at E<.UR "
+"https://docs.python.org/library/codecs.html#standard-encodings> E<.UE .>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:113
+#: en/linkchecker.1:114
 msgid ""
 "The I<FILENAME> and I<ENCODING> parts of the B<none> output type will be "
 "ignored, else if the file already exists, it will be overwritten.  You can "
@@ -350,35 +377,35 @@ msgid ""
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:113
+#: en/linkchecker.1:114
 #, no-wrap
 msgid "B<--no-status>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:116
+#: en/linkchecker.1:117
 msgid "Do not print check status messages."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:116
+#: en/linkchecker.1:117
 #, no-wrap
 msgid "B<--no-warnings>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:119
+#: en/linkchecker.1:120
 msgid "Don't log warnings. Default is to log warnings."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:119
+#: en/linkchecker.1:120
 #, no-wrap
 msgid "B<-o>I<TYPE>[B</>I<ENCODING>], B<--output=>I<TYPE>[B</>I<ENCODING>]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:126
+#: en/linkchecker.1:127
 msgid ""
 "Specify output type as B<text>, B<html>, B<sql>, B<csv>, B<gml>, B<dot>, "
 "B<xml>, B<sitemap>, B<none> or B<blacklist>.  Default type is B<text>. The "
@@ -386,43 +413,43 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:130
+#: en/linkchecker.1:132 en/linkcheckerrc.5:194
 msgid ""
 "The I<ENCODING> specifies the output encoding, the default is that of your "
-"locale. Valid encodings are listed at "
-"B<http://docs.python.org/library/\\:codecs.html#standard-encodings>."
+"locale. Valid encodings are listed at E<.UR "
+"https://docs.python.org/library/codecs.html#standard-encodings> E<.UE .>"
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:130
+#: en/linkchecker.1:132
 #, no-wrap
 msgid "B<-q>, B<--quiet>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:134
+#: en/linkchecker.1:136
 msgid "Quiet operation, an alias for B<-o none>.  This is only useful with B<-F>."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:134
+#: en/linkchecker.1:136
 #, no-wrap
 msgid "B<-v>, B<--verbose>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:137
+#: en/linkchecker.1:139
 msgid "Log all checked URLs. Default is to log only errors and warnings."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:137
+#: en/linkchecker.1:139
 #, no-wrap
 msgid "B<-W>I<REGEX>, B<--warning-regex=>I<REGEX>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:142
+#: en/linkchecker.1:144
 msgid ""
 "Define a regular expression which prints a warning if it matches any content "
 "of the checked link.  This applies only to valid pages, so we can get their "
@@ -430,78 +457,78 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:145
+#: en/linkchecker.1:147
 msgid ""
 "Use this to check for pages that contain some form of error, for example "
 "\"This page has moved\" or \"Oracle Application error\"."
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:148 en/linkcheckerrc.5:467
+#: en/linkchecker.1:150 en/linkcheckerrc.5:475
 msgid ""
 "Note that multiple values can be combined in the regular expression, for "
 "example \"(This page has moved|Oracle Application error)\"."
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:150 en/linkchecker.1:165 en/linkchecker.1:178
+#: en/linkchecker.1:152 en/linkchecker.1:167 en/linkchecker.1:180
 msgid "See section B<REGULAR EXPRESSIONS> for more info."
 msgstr ""
 
 #. type: SS
-#: en/linkchecker.1:150
+#: en/linkchecker.1:152
 #, no-wrap
 msgid "Checking options"
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:151
+#: en/linkchecker.1:153
 #, no-wrap
 msgid "B<--cookiefile=>I<FILENAME>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:155
+#: en/linkchecker.1:157
 msgid ""
 "Read a file with initial cookie data. The cookie data format is explained "
 "below."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:155
+#: en/linkchecker.1:157
 #, no-wrap
 msgid "B<--check-extern>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:158
+#: en/linkchecker.1:160
 msgid "Check external URLs."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:158
+#: en/linkchecker.1:160
 #, no-wrap
 msgid "B<--ignore-url=>I<REGEX>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:161
+#: en/linkchecker.1:163
 msgid "URLs matching the given regular expression will be ignored and not checked."
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:163 en/linkchecker.1:176
+#: en/linkchecker.1:165 en/linkchecker.1:178
 msgid "This option can be given multiple times."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:165
+#: en/linkchecker.1:167
 #, no-wrap
 msgid "B<-N>I<STRING>, B<--nntp-server=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:170 en/linkcheckerrc.5:34
+#: en/linkchecker.1:172 en/linkcheckerrc.5:35
 msgid ""
 "Specify an NNTP server for B<news:> links. Default is the environment "
 "variable B<NNTP_SERVER>. If no host is given, only the syntax of the link is "
@@ -509,24 +536,24 @@ msgid ""
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:170
+#: en/linkchecker.1:172
 #, no-wrap
 msgid "B<--no-follow-url=>I<REGEX>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:174
+#: en/linkchecker.1:176
 msgid "Check but do not recurse into URLs matching the given regular expression."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:178
+#: en/linkchecker.1:180
 #, no-wrap
 msgid "B<-p>, B<--password>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:183
+#: en/linkchecker.1:185
 msgid ""
 "Read a password from console and use it for HTTP and FTP authorization.  For "
 "FTP the default password is B<anonymous@>. For HTTP there is no default "
@@ -534,39 +561,39 @@ msgid ""
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:183
+#: en/linkchecker.1:185
 #, no-wrap
 msgid "B<-r>I<NUMBER>, B<--recursion-level=>I<NUMBER>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:188 en/linkcheckerrc.5:41
+#: en/linkchecker.1:190 en/linkcheckerrc.5:42
 msgid ""
 "Check recursively all links up to given depth.  A negative depth will enable "
 "infinite recursion.  Default depth is infinite."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:188
+#: en/linkchecker.1:190
 #, no-wrap
 msgid "B<--timeout=>I<NUMBER>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:192 en/linkcheckerrc.5:53
+#: en/linkchecker.1:194 en/linkcheckerrc.5:54
 msgid ""
 "Set the timeout for connection attempts in seconds. The default timeout is "
 "60 seconds."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:192
+#: en/linkchecker.1:194
 #, no-wrap
 msgid "B<-u>I<STRING>, B<--user=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:197
+#: en/linkchecker.1:199
 msgid ""
 "Try the given username for HTTP and FTP authorization.  For FTP the default "
 "username is B<anonymous>. For HTTP there is no default username. See also "
@@ -574,13 +601,13 @@ msgid ""
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:197
+#: en/linkchecker.1:199
 #, no-wrap
 msgid "B<--user-agent=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:202 en/linkcheckerrc.5:67
+#: en/linkchecker.1:204 en/linkcheckerrc.5:68
 msgid ""
 "Specify the User-Agent string to send to the HTTP server, for example "
 "\"Mozilla/4.0\". The default is \"LinkChecker/X.Y\" where X.Y is the current "
@@ -588,27 +615,27 @@ msgid ""
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:203
+#: en/linkchecker.1:205
 #, no-wrap
 msgid "CONFIGURATION FILES"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:207
+#: en/linkchecker.1:211
 msgid ""
 "Configuration files can specify all options above. They can also specify "
 "some options that cannot be set on the command line.  See "
-"B<linkcheckerrc>(5) for more info."
+"B<linkcheckerrc>(5)  for more info."
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:208
+#: en/linkchecker.1:212
 #, no-wrap
 msgid "OUTPUT TYPES"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:212
+#: en/linkchecker.1:216
 msgid ""
 "Note that by default only errors and warnings are logged.  You should use "
 "the B<--verbose> option to get the complete URL list, especially when "
@@ -616,24 +643,24 @@ msgid ""
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:213
+#: en/linkchecker.1:217
 #, no-wrap
 msgid "B<text>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:216
+#: en/linkchecker.1:220
 msgid "Standard text logger, logging URLs in keyword: argument fashion."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:216
+#: en/linkchecker.1:220
 #, no-wrap
 msgid "B<html>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:221
+#: en/linkchecker.1:225
 msgid ""
 "Log URLs in keyword: argument fashion, formatted as HTML.  Additionally has "
 "links to the referenced pages. Invalid URLs have HTML and CSS syntax check "
@@ -641,94 +668,94 @@ msgid ""
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:221
+#: en/linkchecker.1:225
 #, no-wrap
 msgid "B<csv>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:224
+#: en/linkchecker.1:228
 msgid "Log check result in CSV format with one URL per line."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:224
+#: en/linkchecker.1:228
 #, no-wrap
 msgid "B<gml>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:227
+#: en/linkchecker.1:231
 msgid "Log parent-child relations between linked URLs as a GML sitemap graph."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:227
+#: en/linkchecker.1:231
 #, no-wrap
 msgid "B<dot>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:230
+#: en/linkchecker.1:234
 msgid "Log parent-child relations between linked URLs as a DOT sitemap graph."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:230
+#: en/linkchecker.1:234
 #, no-wrap
 msgid "B<gxml>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:233
+#: en/linkchecker.1:237
 msgid "Log check result as a GraphXML sitemap graph."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:233
+#: en/linkchecker.1:237
 #, no-wrap
 msgid "B<xml>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:236
+#: en/linkchecker.1:240
 msgid "Log check result as machine-readable XML."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:236
+#: en/linkchecker.1:240
 #, no-wrap
 msgid "B<sitemap>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:240
+#: en/linkchecker.1:245
 msgid ""
-"Log check result as an XML sitemap whose protocol is documented at "
-"B<http://www.sitemaps.org/protocol.html>."
+"Log check result as an XML sitemap whose protocol is documented at E<.UR "
+"https://www.sitemaps.org/protocol.html> E<.UE .>"
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:240
+#: en/linkchecker.1:245
 #, no-wrap
 msgid "B<sql>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:244
+#: en/linkchecker.1:249
 msgid ""
 "Log check result as SQL script with INSERT commands. An example script to "
 "create the initial SQL table is included as create.sql."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:244
+#: en/linkchecker.1:249
 #, no-wrap
 msgid "B<blacklist>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:249
+#: en/linkchecker.1:254
 msgid ""
 "Suitable for cron jobs. Logs the check result into a file "
 "B<~/.linkchecker/blacklist> which only contains entries with invalid URLs "
@@ -736,89 +763,89 @@ msgid ""
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:249
+#: en/linkchecker.1:254
 #, no-wrap
 msgid "B<none>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:252
+#: en/linkchecker.1:257
 msgid "Logs nothing. Suitable for debugging or checking the exit code."
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:253
+#: en/linkchecker.1:258
 #, no-wrap
 msgid "REGULAR EXPRESSIONS"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:256
+#: en/linkchecker.1:264
 msgid ""
-"LinkChecker accepts Python regular expressions.  See "
-"B<http://docs.python.org/\\:howto/regex.html> for an introduction."
+"LinkChecker accepts Python regular expressions.  See E<.UR "
+"https://docs.python.org/howto/regex.html> E<.UE> for an introduction."
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:259
+#: en/linkchecker.1:267
 msgid ""
 "An addition is that a leading exclamation mark negates the regular "
 "expression."
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:260
+#: en/linkchecker.1:268
 #, no-wrap
 msgid "COOKIE FILES"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:263
+#: en/linkchecker.1:271
 msgid ""
 "A cookie file contains standard HTTP header (RFC 2616) data with the "
 "following possible names:"
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:264
+#: en/linkchecker.1:272
 #, no-wrap
 msgid "B<Host> (required)"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:267
+#: en/linkchecker.1:275
 msgid "Sets the domain the cookies are valid for."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:267
+#: en/linkchecker.1:275
 #, no-wrap
 msgid "B<Path> (optional)"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:270
+#: en/linkchecker.1:278
 msgid "Gives the path the cookies are value for; default path is B</>."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:270
+#: en/linkchecker.1:278
 #, no-wrap
 msgid "B<Set-cookie> (required)"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:273
+#: en/linkchecker.1:281
 msgid "Set cookie name/value. Can be given more than once."
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:275
+#: en/linkchecker.1:283
 msgid "Multiple entries are separated by a blank line."
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:279
+#: en/linkchecker.1:287
 msgid ""
 "The example below will send two cookies to all URLs starting with "
 "B<http://example.com/hello/> and one to all URLs starting with "
@@ -826,31 +853,31 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:284
+#: en/linkchecker.1:292
 #, no-wrap
 msgid ""
-" Host: example.com\n"
-" Path: /hello\n"
-" Set-cookie: ID=\"smee\"\n"
-" Set-cookie: spam=\"egg\"\n"
+"  Host: example.com\n"
+"  Path: /hello\n"
+"  Set-cookie: ID=\"smee\"\n"
+"  Set-cookie: spam=\"egg\"\n"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:287
+#: en/linkchecker.1:295
 #, no-wrap
 msgid ""
-" Host: example.org\n"
-" Set-cookie: baggage=\"elitist\"; comment=\"hologram\"\n"
+"  Host: example.org\n"
+"  Set-cookie: baggage=\"elitist\"; comment=\"hologram\"\n"
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:288
+#: en/linkchecker.1:296
 #, no-wrap
 msgid "PROXY SUPPORT"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:295
+#: en/linkchecker.1:303
 msgid ""
 "To use a proxy on Unix or Windows set the $http_proxy, $https_proxy or "
 "$ftp_proxy environment variables to the proxy URL. The URL should be of the "
@@ -861,53 +888,53 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:298
+#: en/linkchecker.1:306
 msgid ""
 "You can also set a comma-separated domain list in the $no_proxy environment "
 "variables to ignore any proxy settings for these domains."
 msgstr ""
 
-#. type: Plain text
-#: en/linkchecker.1:300
+#. type: TP
+#: en/linkchecker.1:306
+#, no-wrap
 msgid "Setting a HTTP proxy on Unix for example looks like this:"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:302
-#, no-wrap
-msgid "  export http_proxy=\"http://proxy.example.com:8080\"\n"
+#: en/linkchecker.1:310
+msgid "B<export http_proxy=\"http://proxy.example.com:8080\">"
 msgstr ""
 
-#. type: Plain text
-#: en/linkchecker.1:304
+#. type: TP
+#: en/linkchecker.1:310
+#, no-wrap
 msgid "Proxy authentication is also supported:"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:306
-#, no-wrap
-msgid "  export http_proxy=\"http://user1:mypass@proxy.example.org:8081\"\n"
+#: en/linkchecker.1:314
+msgid "B<export http_proxy=\"http://user1:mypass@proxy.example.org:8081\">"
 msgstr ""
 
-#. type: Plain text
-#: en/linkchecker.1:308
+#. type: TP
+#: en/linkchecker.1:314
+#, no-wrap
 msgid "Setting a proxy on the Windows command prompt:"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:310
-#, no-wrap
-msgid "  set http_proxy=http://proxy.example.com:8080\n"
+#: en/linkchecker.1:318
+msgid "B<set http_proxy=http://proxy.example.com:8080>"
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:311
+#: en/linkchecker.1:318
 #, no-wrap
 msgid "PERFORMED CHECKS"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:317
+#: en/linkchecker.1:324
 msgid ""
 "All URLs have to pass a preliminary syntax test. Minor quoting mistakes will "
 "issue a warning, all other invalid syntax issues are errors.  After the "
@@ -916,13 +943,13 @@ msgid ""
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:318
+#: en/linkchecker.1:324
 #, no-wrap
 msgid "HTTP links (B<http:>, B<https:>)"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:325
+#: en/linkchecker.1:331
 msgid ""
 "After connecting to the given HTTP server the given path or query is "
 "requested. All redirections are followed, and if user/password is given it "
@@ -931,18 +958,18 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:327
+#: en/linkchecker.1:333
 msgid "HTML page contents are checked for recursion."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:327
+#: en/linkchecker.1:333
 #, no-wrap
 msgid "Local files (B<file:>)"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:332
+#: en/linkchecker.1:338
 msgid ""
 "A regular, readable file that can be opened is valid. A readable directory "
 "is also valid. All other files, for example device files, unreadable or "
@@ -950,18 +977,18 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:334
+#: en/linkchecker.1:340
 msgid "HTML or other parseable file contents are checked for recursion."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:334
+#: en/linkchecker.1:340
 #, no-wrap
 msgid "Mail links (B<mailto:>)"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:339
+#: en/linkchecker.1:345
 msgid ""
 "A mailto: link eventually resolves to a list of email addresses.  If one "
 "address fails, the whole list will fail.  For each mail address we check the "
@@ -969,120 +996,128 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/linkchecker.1:347
+msgid "1) Check the adress syntax, both of the part before and after the @ sign."
+msgstr ""
+
+#. type: Plain text
 #: en/linkchecker.1:349
-#, no-wrap
+msgid "2) Look up the MX DNS records. If we found no MX record, print an error."
+msgstr ""
+
+#. type: Plain text
+#: en/linkchecker.1:353
 msgid ""
-"  1) Check the adress syntax, both of the part before and after\n"
-"     the @ sign.\n"
-"  2) Look up the MX DNS records. If we found no MX record,\n"
-"     print an error.\n"
-"  3) Check if one of the mail hosts accept an SMTP connection.\n"
-"     Check hosts with higher priority first.\n"
-"     If no host accepts SMTP, we print a warning.\n"
-"  4) Try to verify the address with the VRFY command. If we got\n"
-"     an answer, print the verified address as an info.\n"
+"3) Check if one of the mail hosts accept an SMTP connection.  Check hosts "
+"with higher priority first.  If no host accepts SMTP, we print a warning."
+msgstr ""
+
+#. type: Plain text
+#: en/linkchecker.1:356
+msgid ""
+"4) Try to verify the address with the VRFY command. If we got an answer, "
+"print the verified address as an info."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:349
+#: en/linkchecker.1:357
 #, no-wrap
 msgid "FTP links (B<ftp:>)"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:353
-#, no-wrap
-msgid "  For FTP links we do:\n"
+#: en/linkchecker.1:360
+msgid "For FTP links we do:"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:359
-#, no-wrap
-msgid ""
-"  1) connect to the specified host\n"
-"  2) try to login with the given user and password. The default\n"
-"     user is ``anonymous``, the default password is ``anonymous@``.\n"
-"  3) try to change to the given directory\n"
-"  4) list the file with the NLST command\n"
-msgstr ""
-
-#. type: TP
-#: en/linkchecker.1:360
-#, no-wrap
-msgid "Telnet links (``telnet:``)"
+#: en/linkchecker.1:362
+msgid "1) connect to the specified host"
 msgstr ""
 
 #. type: Plain text
 #: en/linkchecker.1:365
-#, no-wrap
 msgid ""
-"  We try to connect and if user/password are given, login to the\n"
-"  given telnet server.\n"
+"2) try to login with the given user and password. The default user is "
+"B<anonymous>, the default password is B<anonymous@>."
+msgstr ""
+
+#. type: Plain text
+#: en/linkchecker.1:367
+msgid "3) try to change to the given directory"
+msgstr ""
+
+#. type: Plain text
+#: en/linkchecker.1:369
+msgid "4) list the file with the NLST command"
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:366
+#: en/linkchecker.1:370
 #, no-wrap
-msgid "NNTP links (``news:``, ``snews:``, ``nntp``)"
+msgid "Telnet links (B<telnet:>)"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:371
-#, no-wrap
+#: en/linkchecker.1:374
 msgid ""
-"  We try to connect to the given NNTP server. If a news group or\n"
-"  article is specified, try to request it from the server.\n"
+"We try to connect and if user/password are given, login to the given telnet "
+"server."
 msgstr ""
 
 #. type: TP
-#: en/linkchecker.1:372
+#: en/linkchecker.1:375
 #, no-wrap
-msgid "Unsupported links (``javascript:``, etc.)"
+msgid "NNTP links (B<news:>, B<snews:>, B<nntp>)"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:377
-#, no-wrap
+#: en/linkchecker.1:379
 msgid ""
-"  An unsupported link will only print a warning. No further checking\n"
-"  will be made.\n"
+"We try to connect to the given NNTP server. If a news group or article is "
+"specified, try to request it from the server."
+msgstr ""
+
+#. type: TP
+#: en/linkchecker.1:380
+#, no-wrap
+msgid "Unsupported links (B<javascript:>, etc.)"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:381
-#, no-wrap
+#: en/linkchecker.1:384
 msgid ""
-"  The complete list of recognized, but unsupported links can be found\n"
-"  in the B<linkcheck/checker/unknownurl.py> source file.\n"
-"  The most prominent of them should be JavaScript links.\n"
+"An unsupported link will only print a warning. No further checking will be "
+"made."
+msgstr ""
+
+#. type: Plain text
+#: en/linkchecker.1:392
+msgid ""
+"The complete list of recognized, but unsupported links can be found in the "
+"E<.UR "
+"https://github.com/linkchecker/linkchecker/blob/master/linkcheck/checker/unknownurl.py> "
+"linkcheck/checker/unknownurl.py E<.UE> source file.  The most prominent of "
+"them should be JavaScript links."
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:382 en/linkcheckerrc.5:443
+#: en/linkchecker.1:392 en/linkcheckerrc.5:451
 #, no-wrap
 msgid "PLUGINS"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:384
-msgid "There are two plugin types: connection and content plugins."
-msgstr ""
-
-#. type: Plain text
-#: en/linkchecker.1:387
-msgid "Connection plugins are run after a successful connection to the URL host."
-msgstr ""
-
-#. type: Plain text
-#: en/linkchecker.1:391
+#: en/linkchecker.1:399
 msgid ""
-"Content plugins are run if the URL type has content (mailto: URLs have no "
-"content for example) and if the check is not forbidden (ie. by HTTP "
-"robots.txt)."
+"There are two plugin types: connection and content plugins.  Connection "
+"plugins are run after a successful connection to the URL host.  Content "
+"plugins are run if the URL type has content (mailto: URLs have no content "
+"for example) and if the check is not forbidden (ie. by HTTP robots.txt)."
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:395
+#: en/linkchecker.1:404
 msgid ""
 "See B<linkchecker --list-plugins> for a list of plugins and their "
 "documentation. All plugins are enabled via the B<linkcheckerrc>(5)  "
@@ -1090,25 +1125,25 @@ msgid ""
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:396
+#: en/linkchecker.1:405
 #, no-wrap
 msgid "RECURSION"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:399
+#: en/linkchecker.1:408
 msgid ""
 "Before descending recursively into a URL, it has to fulfill several "
 "conditions. They are checked in this order:"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:401
+#: en/linkchecker.1:410
 msgid "1. A URL must be valid."
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:407
+#: en/linkchecker.1:416
 #, no-wrap
 msgid ""
 "2. A URL must be parseable. This currently includes HTML files,\n"
@@ -1119,7 +1154,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:410
+#: en/linkchecker.1:419
 #, no-wrap
 msgid ""
 "3. The URL content must be retrievable. This is usually the case\n"
@@ -1127,7 +1162,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:413
+#: en/linkchecker.1:422
 #, no-wrap
 msgid ""
 "4. The maximum recursion level must not be exceeded. It is configured\n"
@@ -1135,7 +1170,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:416
+#: en/linkchecker.1:425
 #, no-wrap
 msgid ""
 "5. It must not match the ignored URL list. This is controlled with\n"
@@ -1143,7 +1178,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:420
+#: en/linkchecker.1:429
 #, no-wrap
 msgid ""
 "6. The Robots Exclusion Protocol must allow links in the URL to be\n"
@@ -1152,20 +1187,20 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:423
+#: en/linkchecker.1:432
 msgid ""
 "Note that the directory recursion reads all files in that directory, not "
 "just a subset like B<index.htm*>."
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:424
+#: en/linkchecker.1:433
 #, no-wrap
 msgid "NOTES"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:429
+#: en/linkchecker.1:438
 msgid ""
 "URLs on the commandline starting with B<ftp.> are treated like "
 "B<ftp://ftp.>, URLs starting with B<www.> are treated like B<http://www.>.  "
@@ -1173,7 +1208,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:434
+#: en/linkchecker.1:443
 msgid ""
 "If you have your system configured to automatically establish a connection "
 "to the internet (e.g. with diald), it will connect when checking links not "
@@ -1182,106 +1217,106 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:436
+#: en/linkchecker.1:445
 msgid "Javascript links are not supported."
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:439
+#: en/linkchecker.1:448
 msgid ""
 "If your platform does not support threading, LinkChecker disables it "
 "automatically."
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:441
+#: en/linkchecker.1:450
 msgid "You can supply multiple user/password pairs in a configuration file."
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:444
+#: en/linkchecker.1:453
 msgid ""
 "When checking B<news:> links the given NNTP host doesn't need to be the same "
 "as the host of the user browsing your pages."
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:445
+#: en/linkchecker.1:454
 #, no-wrap
 msgid "ENVIRONMENT"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:447
+#: en/linkchecker.1:456
 msgid "B<NNTP_SERVER> - specifies default NNTP server"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:449
+#: en/linkchecker.1:458
 msgid "B<http_proxy> - specifies default HTTP proxy server"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:451
+#: en/linkchecker.1:460
 msgid "B<ftp_proxy> - specifies default FTP proxy server"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:453
+#: en/linkchecker.1:462
 msgid ""
 "B<no_proxy> - comma-separated list of domains to not contact over a proxy "
 "server"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:455
+#: en/linkchecker.1:464
 msgid "B<LC_MESSAGES>, B<LANG>, B<LANGUAGE> - specify output language"
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:456
+#: en/linkchecker.1:465
 #, no-wrap
 msgid "RETURN VALUE"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:458
+#: en/linkchecker.1:467
 msgid "The return value is 2 when"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:460
+#: en/linkchecker.1:469
 msgid "a program error occurred."
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:462
+#: en/linkchecker.1:471
 msgid "The return value is 1 when"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:464
+#: en/linkchecker.1:473
 msgid "invalid links were found or"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:466
+#: en/linkchecker.1:475
 msgid "link warnings were found and warnings are enabled"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:468
+#: en/linkchecker.1:477
 msgid "Else the return value is zero."
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:469
+#: en/linkchecker.1:478
 #, no-wrap
 msgid "LIMITATIONS"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:473
+#: en/linkchecker.1:482
 msgid ""
 "LinkChecker consumes memory for each queued URL to check. With thousands of "
 "queued URLs the amount of consumed memory can become quite large. This might "
@@ -1289,83 +1324,77 @@ msgid ""
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:474
+#: en/linkchecker.1:483
 #, no-wrap
 msgid "FILES"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:476
+#: en/linkchecker.1:485
 msgid "B<~/.linkchecker/linkcheckerrc> - default configuration file"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:478
+#: en/linkchecker.1:487
 msgid "B<~/.linkchecker/blacklist> - default blacklist logger output filename"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:480
+#: en/linkchecker.1:489
 msgid "B<linkchecker-out.>I<TYPE> - default logger file output name"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:482
+#: en/linkchecker.1:493
 msgid ""
-"B<http://docs.python.org/library/codecs.html#standard-encodings> - valid "
-"output encodings"
+"E<.UR https://docs.python.org/library/codecs.html#standard-encodings> E<.UE> "
+"- valid output encodings"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:484
+#: en/linkchecker.1:497
 msgid ""
-"B<http://docs.python.org/howto/regex.html> - regular expression "
+"E<.UR https://docs.python.org/howto/regex.html> E<.UE> - regular expression "
 "documentation"
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:485 en/linkcheckerrc.5:553
+#: en/linkchecker.1:498 en/linkcheckerrc.5:565
 #, no-wrap
 msgid "SEE ALSO"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:487
+#: en/linkchecker.1:500
 msgid "B<linkcheckerrc>(5)"
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:488 en/linkcheckerrc.5:556
+#: en/linkchecker.1:501 en/linkcheckerrc.5:568
 #, no-wrap
 msgid "AUTHOR"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:490 en/linkcheckerrc.5:558
+#: en/linkchecker.1:503 en/linkcheckerrc.5:570
 msgid "Bastian Kleineidam E<lt>bastian.kleineidam@web.deE<gt>"
 msgstr ""
 
 #. type: SH
-#: en/linkchecker.1:491 en/linkcheckerrc.5:559
+#: en/linkchecker.1:504 en/linkcheckerrc.5:571
 #, no-wrap
 msgid "COPYRIGHT"
 msgstr ""
 
 #. type: Plain text
-#: en/linkchecker.1:492 en/linkcheckerrc.5:560
+#: en/linkchecker.1:505 en/linkcheckerrc.5:572
 msgid "Copyright \\(co 2000-2014 Bastian Kleineidam"
 msgstr ""
 
 #. type: TH
 #: en/linkcheckerrc.5:1
 #, no-wrap
-msgid "linkcheckerrc"
-msgstr ""
-
-#. type: TH
-#: en/linkcheckerrc.5:1
-#, no-wrap
-msgid "2007-11-30"
+msgid "LINKCHECKERRC"
 msgstr ""
 
 #. type: Plain text
@@ -1406,32 +1435,32 @@ msgid "B<cookiefile=>I<filename>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:17
+#: en/linkcheckerrc.5:18
 msgid ""
 "Read a file with initial cookie data. The cookie data format is explained in "
-"linkchecker(1)."
+"B<linkchecker>(1)."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:19
+#: en/linkcheckerrc.5:20
 msgid "Command line option: B<--cookiefile>"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:19
+#: en/linkcheckerrc.5:20
 #, no-wrap
 msgid "B<localwebroot=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:23
+#: en/linkcheckerrc.5:24
 msgid ""
 "When checking absolute URLs inside local files, the given root directory is "
 "used as base URL."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:27
+#: en/linkcheckerrc.5:28
 msgid ""
 "Note that the given directory must have URL syntax, so it must use a slash "
 "to join directories instead of a backslash.  And the given directory must "
@@ -1439,86 +1468,88 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:29 en/linkcheckerrc.5:77 en/linkcheckerrc.5:85 en/linkcheckerrc.5:93 en/linkcheckerrc.5:111 en/linkcheckerrc.5:117 en/linkcheckerrc.5:228 en/linkcheckerrc.5:245
+#: en/linkcheckerrc.5:30 en/linkcheckerrc.5:78 en/linkcheckerrc.5:86
+#: en/linkcheckerrc.5:94 en/linkcheckerrc.5:112 en/linkcheckerrc.5:118
+#: en/linkcheckerrc.5:230 en/linkcheckerrc.5:248
 msgid "Command line option: none"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:29
+#: en/linkcheckerrc.5:30
 #, no-wrap
 msgid "B<nntpserver=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:36
+#: en/linkcheckerrc.5:37
 msgid "Command line option: B<--nntp-server>"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:36
+#: en/linkcheckerrc.5:37
 #, no-wrap
 msgid "B<recursionlevel=>I<NUMBER>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:43
+#: en/linkcheckerrc.5:44
 msgid "Command line option: B<--recursion-level>"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:43
+#: en/linkcheckerrc.5:44
 #, no-wrap
 msgid "B<threads=>I<NUMBER>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:49
+#: en/linkcheckerrc.5:50
 msgid "Command line option: B<--threads>"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:49
+#: en/linkcheckerrc.5:50
 #, no-wrap
 msgid "B<timeout=>I<NUMBER>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:55 en/linkcheckerrc.5:62
+#: en/linkcheckerrc.5:56 en/linkcheckerrc.5:63
 msgid "Command line option: B<--timeout>"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:55
+#: en/linkcheckerrc.5:56
 #, no-wrap
 msgid "B<aborttimeout=>I<NUMBER>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:60
+#: en/linkcheckerrc.5:61
 msgid ""
 "Time to wait for checks to finish after the user aborts the first time (with "
 "Ctrl-C or the abort button).  The default abort timeout is 300 seconds."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:62
+#: en/linkcheckerrc.5:63
 #, no-wrap
 msgid "B<useragent=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:69
+#: en/linkcheckerrc.5:70
 msgid "Command line option: B<--user-agent>"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:69
+#: en/linkcheckerrc.5:70
 #, no-wrap
 msgid "B<sslverify=>[B<0>|B<1>|I<filename>]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:75
+#: en/linkcheckerrc.5:76
 msgid ""
 "If set to zero disables SSL certificate checking.  If set to one (the "
 "default) enables SSL certificate checking with the provided CA certificate "
@@ -1526,157 +1557,157 @@ msgid ""
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:77
+#: en/linkcheckerrc.5:78
 #, no-wrap
 msgid "B<maxrunseconds=>I<NUMBER>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:81
+#: en/linkcheckerrc.5:82
 msgid ""
 "Stop checking new URLs after the given number of seconds. Same as if the "
 "user stops (by hitting Ctrl-C) after the given number of seconds."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:83
+#: en/linkcheckerrc.5:84
 msgid "The default is not to stop until all URLs are checked."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:85
+#: en/linkcheckerrc.5:86
 #, no-wrap
 msgid "B<maxnumurls=>I<NUMBER>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:89
+#: en/linkcheckerrc.5:90
 msgid ""
 "Maximum number of URLs to check. New URLs will not be queued after the given "
 "number of URLs is checked."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:91
+#: en/linkcheckerrc.5:92
 msgid "The default is to queue and check all URLs."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:93
+#: en/linkcheckerrc.5:94
 #, no-wrap
 msgid "B<maxrequestspersecond=>I<NUMBER>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:96
+#: en/linkcheckerrc.5:97
 msgid "Limit the maximum number of requests per second to one host."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:96
+#: en/linkcheckerrc.5:97
 #, no-wrap
 msgid "B<allowedschemes=>I<NAME>[B<,>I<NAME>...]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:99
+#: en/linkcheckerrc.5:100
 msgid "Allowed URL schemes as comma-separated list."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:99
+#: en/linkcheckerrc.5:100
 #, no-wrap
 msgid "[filtering]"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:100
+#: en/linkcheckerrc.5:101
 #, no-wrap
 msgid "B<ignore=>I<REGEX> (MULTILINE)"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:103
+#: en/linkcheckerrc.5:104
 msgid "Only check syntax of URLs matching the given regular expressions."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:105
+#: en/linkcheckerrc.5:106
 msgid "Command line option: B<--ignore-url>"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:105
+#: en/linkcheckerrc.5:106
 #, no-wrap
 msgid "B<ignorewarnings=>I<NAME>[B<,>I<NAME>...]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:109
+#: en/linkcheckerrc.5:110
 msgid ""
 "Ignore the comma-separated list of warnings. See B<WARNINGS> for the list of "
 "supported warnings."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:111
+#: en/linkcheckerrc.5:112
 #, no-wrap
 msgid "B<internlinks=>I<REGEX>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:115
+#: en/linkcheckerrc.5:116
 msgid ""
 "Regular expression to add more URLs recognized as internal links.  Default "
 "is that URLs given on the command line are internal."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:117
+#: en/linkcheckerrc.5:118
 #, no-wrap
 msgid "B<nofollow=>I<REGEX> (MULTILINE)"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:121
+#: en/linkcheckerrc.5:122
 msgid "Check but do not recurse into URLs matching the given regular expressions."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:123
+#: en/linkcheckerrc.5:124
 msgid "Command line option: B<--no-follow-url>"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:123
+#: en/linkcheckerrc.5:124
 #, no-wrap
 msgid "B<checkextern=>[B<0>|B<1>]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:126
+#: en/linkcheckerrc.5:127
 msgid "Check external links. Default is to check internal links only."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:128
+#: en/linkcheckerrc.5:129
 msgid "Command line option: B<--checkextern>"
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:128
+#: en/linkcheckerrc.5:129
 #, no-wrap
 msgid "[authentication]"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:129
+#: en/linkcheckerrc.5:130
 #, no-wrap
 msgid "B<entry=>I<REGEX> I<USER> [I<PASS>] (MULTILINE)"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:135
+#: en/linkcheckerrc.5:136
 msgid ""
 "Provide different user/password pairs for different link types.  Entries are "
 "a triple (URL regex, username, password)  or a tuple (URL regex, username), "
@@ -1684,14 +1715,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:138
+#: en/linkcheckerrc.5:139
 msgid ""
 "The password is optional and if missing it has to be entered at the "
 "commandline."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:144
+#: en/linkcheckerrc.5:145
 msgid ""
 "If the regular expression matches the checked URL, the given user/password "
 "pair is used for authentication. The commandline options B<-u> and B<-p> "
@@ -1701,72 +1732,72 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:146
+#: en/linkcheckerrc.5:147
 msgid "Command line option: B<-u>, B<-p>"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:146
+#: en/linkcheckerrc.5:147
 #, no-wrap
 msgid "B<loginurl=>I<URL>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:150
+#: en/linkcheckerrc.5:151
 msgid ""
 "A login URL to be visited before checking. Also needs authentication data "
 "set for it."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:150
+#: en/linkcheckerrc.5:151
 #, no-wrap
 msgid "B<loginuserfield=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:153
+#: en/linkcheckerrc.5:154
 msgid "The name of the user CGI field. Default name is B<login>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:153
+#: en/linkcheckerrc.5:154
 #, no-wrap
 msgid "B<loginpasswordfield=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:156
+#: en/linkcheckerrc.5:157
 msgid "The name of the password CGI field. Default name is B<password>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:156
+#: en/linkcheckerrc.5:157
 #, no-wrap
 msgid "B<loginextrafields=>I<NAME>B<:>I<VALUE> (MULTILINE)"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:160
+#: en/linkcheckerrc.5:161
 msgid ""
 "Optionally any additional CGI name/value pairs. Note that the default values "
 "are submitted automatically."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:160
+#: en/linkcheckerrc.5:161
 #, no-wrap
 msgid "[output]"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:161
+#: en/linkcheckerrc.5:162
 #, no-wrap
 msgid "B<debug=>I<STRING>[B<,>I<STRING>...]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:167
+#: en/linkcheckerrc.5:168
 msgid ""
 "Print debugging output for the given modules.  Available debug modules are "
 "B<cmdline>, B<checking>, B<cache>, B<dns>, B<thread>, B<plugins> and "
@@ -1774,25 +1805,25 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:169
+#: en/linkcheckerrc.5:170
 msgid "Command line option: B<--debug>"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:169
+#: en/linkcheckerrc.5:170
 #, no-wrap
 msgid "B<fileoutput=>I<TYPE>[B<,>I<TYPE>...]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:174
+#: en/linkcheckerrc.5:175
 msgid ""
 "Output to a files B<linkchecker-out.>I<TYPE>, "
 "B<$HOME/.linkchecker/blacklist> for B<blacklist> output."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:180
+#: en/linkcheckerrc.5:181
 msgid ""
 "Valid file output types are B<text>, B<html>, B<sql>, B<csv>, B<gml>, "
 "B<dot>, B<xml>, B<none> or B<blacklist> Default is no file output. The "
@@ -1801,18 +1832,18 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:182
+#: en/linkcheckerrc.5:183
 msgid "Command line option: B<--file-output>"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:182
+#: en/linkcheckerrc.5:183
 #, no-wrap
 msgid "B<log=>I<TYPE>[B</>I<ENCODING>]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:188
+#: en/linkcheckerrc.5:189
 msgid ""
 "Specify output type as B<text>, B<html>, B<sql>, B<csv>, B<gml>, B<dot>, "
 "B<xml>, B<none> or B<blacklist>.  Default type is B<text>. The various "
@@ -1820,144 +1851,144 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:192
-msgid ""
-"The I<ENCODING> specifies the output encoding, the default is that of your "
-"locale. Valid encodings are listed at "
-"B<http://docs.python.org/library/codecs.html#standard-encodings>."
-msgstr ""
-
-#. type: Plain text
-#: en/linkcheckerrc.5:194
+#: en/linkcheckerrc.5:196
 msgid "Command line option: B<--output>"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:194
+#: en/linkcheckerrc.5:196
 #, no-wrap
 msgid "B<quiet=>[B<0>|B<1>]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:198
+#: en/linkcheckerrc.5:200
 msgid ""
 "If set, operate quiet. An alias for B<log=none>.  This is only useful with "
 "B<fileoutput>."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:200 en/linkcheckerrc.5:210
+#: en/linkcheckerrc.5:202 en/linkcheckerrc.5:212
 msgid "Command line option: B<--verbose>"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:200
+#: en/linkcheckerrc.5:202
 #, no-wrap
 msgid "B<status=>[B<0>|B<1>]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:203
+#: en/linkcheckerrc.5:205
 msgid "Control printing check status messages. Default is 1."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:205
+#: en/linkcheckerrc.5:207
 msgid "Command line option: B<--no-status>"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:205
+#: en/linkcheckerrc.5:207
 #, no-wrap
 msgid "B<verbose=>[B<0>|B<1>]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:208
+#: en/linkcheckerrc.5:210
 msgid ""
 "If set log all checked URLs once. Default is to log only errors and "
 "warnings."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:210
+#: en/linkcheckerrc.5:212
 #, no-wrap
 msgid "B<warnings=>[B<0>|B<1>]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:213
+#: en/linkcheckerrc.5:215
 msgid "If set log warnings. Default is to log warnings."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:215
+#: en/linkcheckerrc.5:217
 msgid "Command line option: B<--no-warnings>"
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:215
+#: en/linkcheckerrc.5:217
 #, no-wrap
 msgid "[text]"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:216 en/linkcheckerrc.5:279 en/linkcheckerrc.5:289 en/linkcheckerrc.5:299 en/linkcheckerrc.5:315 en/linkcheckerrc.5:331 en/linkcheckerrc.5:362 en/linkcheckerrc.5:369 en/linkcheckerrc.5:379 en/linkcheckerrc.5:389
+#: en/linkcheckerrc.5:218 en/linkcheckerrc.5:282 en/linkcheckerrc.5:292
+#: en/linkcheckerrc.5:302 en/linkcheckerrc.5:318 en/linkcheckerrc.5:334
+#: en/linkcheckerrc.5:365 en/linkcheckerrc.5:372 en/linkcheckerrc.5:382
+#: en/linkcheckerrc.5:392
 #, no-wrap
 msgid "B<filename=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:220
+#: en/linkcheckerrc.5:222
 msgid ""
 "Specify output filename for text logging. Default filename is "
 "B<linkchecker-out.txt>."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:222
+#: en/linkcheckerrc.5:224
 msgid "Command line option: B<--file-output=>"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:222 en/linkcheckerrc.5:282 en/linkcheckerrc.5:292 en/linkcheckerrc.5:302 en/linkcheckerrc.5:318 en/linkcheckerrc.5:334 en/linkcheckerrc.5:372 en/linkcheckerrc.5:382 en/linkcheckerrc.5:392
+#: en/linkcheckerrc.5:224 en/linkcheckerrc.5:285 en/linkcheckerrc.5:295
+#: en/linkcheckerrc.5:305 en/linkcheckerrc.5:321 en/linkcheckerrc.5:337
+#: en/linkcheckerrc.5:375 en/linkcheckerrc.5:385 en/linkcheckerrc.5:395
 #, no-wrap
 msgid "B<parts=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:226
+#: en/linkcheckerrc.5:228
 msgid ""
 "Comma-separated list of parts that have to be logged.  See B<LOGGER PARTS> "
 "below."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:228 en/linkcheckerrc.5:285 en/linkcheckerrc.5:295 en/linkcheckerrc.5:305 en/linkcheckerrc.5:321 en/linkcheckerrc.5:337 en/linkcheckerrc.5:365 en/linkcheckerrc.5:375 en/linkcheckerrc.5:385 en/linkcheckerrc.5:395
+#: en/linkcheckerrc.5:230 en/linkcheckerrc.5:288 en/linkcheckerrc.5:298
+#: en/linkcheckerrc.5:308 en/linkcheckerrc.5:324 en/linkcheckerrc.5:340
+#: en/linkcheckerrc.5:368 en/linkcheckerrc.5:378 en/linkcheckerrc.5:388
+#: en/linkcheckerrc.5:398
 #, no-wrap
 msgid "B<encoding=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:232
+#: en/linkcheckerrc.5:235
 msgid ""
-"Valid encodings are listed in "
-"B<http://docs.python.org/library/codecs.html#standard-encodings>."
+"Valid encodings are listed in E<.UR "
+"https://docs.python.org/library/codecs.html#standard-encodings> E<.UE .>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:234
+#: en/linkcheckerrc.5:237
 msgid "Default encoding is B<iso-8859-15>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:234
+#: en/linkcheckerrc.5:237
 #, no-wrap
 msgid "I<color*>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:243
+#: en/linkcheckerrc.5:246
 msgid ""
 "Color settings for the various log parts, syntax is I<color> or "
 "I<type>B<;>I<color>. The I<type> can be B<bold>, B<light>, B<blink>, "
@@ -1967,360 +1998,526 @@ msgid ""
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:245
+#: en/linkcheckerrc.5:248
 #, no-wrap
 msgid "B<colorparent=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:248
+#: en/linkcheckerrc.5:251
 msgid "Set parent color. Default is B<white>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:248
+#: en/linkcheckerrc.5:251
 #, no-wrap
 msgid "B<colorurl=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:251
+#: en/linkcheckerrc.5:254
 msgid "Set URL color. Default is B<default>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:251
+#: en/linkcheckerrc.5:254
 #, no-wrap
 msgid "B<colorname=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:254
+#: en/linkcheckerrc.5:257
 msgid "Set name color. Default is B<default>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:254
+#: en/linkcheckerrc.5:257
 #, no-wrap
 msgid "B<colorreal=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:257
+#: en/linkcheckerrc.5:260
 msgid "Set real URL color. Default is B<cyan>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:257
+#: en/linkcheckerrc.5:260
 #, no-wrap
 msgid "B<colorbase=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:260
+#: en/linkcheckerrc.5:263
 msgid "Set base URL color. Default is B<purple>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:260
+#: en/linkcheckerrc.5:263
 #, no-wrap
 msgid "B<colorvalid=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:263
+#: en/linkcheckerrc.5:266
 msgid "Set valid color. Default is B<bold;green>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:263
+#: en/linkcheckerrc.5:266
 #, no-wrap
 msgid "B<colorinvalid=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:266
+#: en/linkcheckerrc.5:269
 msgid "Set invalid color. Default is B<bold;red>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:266
+#: en/linkcheckerrc.5:269
 #, no-wrap
 msgid "B<colorinfo=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:269
+#: en/linkcheckerrc.5:272
 msgid "Set info color. Default is B<default>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:269
+#: en/linkcheckerrc.5:272
 #, no-wrap
 msgid "B<colorwarning=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:272
+#: en/linkcheckerrc.5:275
 msgid "Set warning color. Default is B<bold;yellow>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:272
+#: en/linkcheckerrc.5:275
 #, no-wrap
 msgid "B<colordltime=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:275
+#: en/linkcheckerrc.5:278
 msgid "Set download time color. Default is B<default>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:275
+#: en/linkcheckerrc.5:278
 #, no-wrap
 msgid "B<colorreset=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:278
+#: en/linkcheckerrc.5:281
 msgid "Set reset color. Default is B<default>."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:278
+#: en/linkcheckerrc.5:281
 #, no-wrap
 msgid "[gml]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:282 en/linkcheckerrc.5:285 en/linkcheckerrc.5:288 en/linkcheckerrc.5:292 en/linkcheckerrc.5:295 en/linkcheckerrc.5:298 en/linkcheckerrc.5:302 en/linkcheckerrc.5:305 en/linkcheckerrc.5:308 en/linkcheckerrc.5:318 en/linkcheckerrc.5:321 en/linkcheckerrc.5:324 en/linkcheckerrc.5:334 en/linkcheckerrc.5:337 en/linkcheckerrc.5:340 en/linkcheckerrc.5:365 en/linkcheckerrc.5:368 en/linkcheckerrc.5:372 en/linkcheckerrc.5:375 en/linkcheckerrc.5:378 en/linkcheckerrc.5:382 en/linkcheckerrc.5:385 en/linkcheckerrc.5:388 en/linkcheckerrc.5:392 en/linkcheckerrc.5:395 en/linkcheckerrc.5:398
+#: en/linkcheckerrc.5:285 en/linkcheckerrc.5:288 en/linkcheckerrc.5:291
+#: en/linkcheckerrc.5:295 en/linkcheckerrc.5:298 en/linkcheckerrc.5:301
+#: en/linkcheckerrc.5:305 en/linkcheckerrc.5:308 en/linkcheckerrc.5:311
+#: en/linkcheckerrc.5:321 en/linkcheckerrc.5:324 en/linkcheckerrc.5:327
+#: en/linkcheckerrc.5:337 en/linkcheckerrc.5:340 en/linkcheckerrc.5:343
+#: en/linkcheckerrc.5:368 en/linkcheckerrc.5:371 en/linkcheckerrc.5:375
+#: en/linkcheckerrc.5:378 en/linkcheckerrc.5:381 en/linkcheckerrc.5:385
+#: en/linkcheckerrc.5:388 en/linkcheckerrc.5:391 en/linkcheckerrc.5:395
+#: en/linkcheckerrc.5:398 en/linkcheckerrc.5:401
 msgid "See [text] section above."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:288
+#: en/linkcheckerrc.5:291
 #, no-wrap
 msgid "[dot]"
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:298
+#: en/linkcheckerrc.5:301
 #, no-wrap
 msgid "[csv]"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:308 en/linkcheckerrc.5:327
+#: en/linkcheckerrc.5:311 en/linkcheckerrc.5:330
 #, no-wrap
 msgid "B<separator=>I<CHAR>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:311
+#: en/linkcheckerrc.5:314
 msgid "Set CSV separator. Default is a comma (B<,>)."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:311
+#: en/linkcheckerrc.5:314
 #, no-wrap
 msgid "B<quotechar=>I<CHAR>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:314
+#: en/linkcheckerrc.5:317
 msgid "Set CSV quote character. Default is a double quote (B<\">)."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:314
+#: en/linkcheckerrc.5:317
 #, no-wrap
 msgid "[sql]"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:324
+#: en/linkcheckerrc.5:327
 #, no-wrap
 msgid "B<dbname=>I<STRING>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:327
+#: en/linkcheckerrc.5:330
 msgid "Set database name to store into. Default is B<linksdb>."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:330
+#: en/linkcheckerrc.5:333
 msgid "Set SQL command separator character. Default is a semicolon (B<;>)."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:330
+#: en/linkcheckerrc.5:333
 #, no-wrap
 msgid "[html]"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:340
+#: en/linkcheckerrc.5:343
 #, no-wrap
 msgid "B<colorbackground=>I<COLOR>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:343
+#: en/linkcheckerrc.5:346
 msgid "Set HTML background color. Default is B<#fff7e5>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:343
+#: en/linkcheckerrc.5:346
 #, no-wrap
 msgid "B<colorurl=>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:346
+#: en/linkcheckerrc.5:349
 msgid "Set HTML URL color. Default is B<#dcd5cf>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:346
+#: en/linkcheckerrc.5:349
 #, no-wrap
 msgid "B<colorborder=>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:349
+#: en/linkcheckerrc.5:352
 msgid "Set HTML border color. Default is B<#000000>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:349
+#: en/linkcheckerrc.5:352
 #, no-wrap
 msgid "B<colorlink=>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:352
+#: en/linkcheckerrc.5:355
 msgid "Set HTML link color. Default is B<#191c83>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:352
+#: en/linkcheckerrc.5:355
 #, no-wrap
 msgid "B<colorwarning=>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:355
+#: en/linkcheckerrc.5:358
 msgid "Set HTML warning color. Default is B<#e0954e>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:355
+#: en/linkcheckerrc.5:358
 #, no-wrap
 msgid "B<colorerror=>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:358
+#: en/linkcheckerrc.5:361
 msgid "Set HTML error color. Default is B<#db4930>."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:358
+#: en/linkcheckerrc.5:361
 #, no-wrap
 msgid "B<colorok=>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:361
+#: en/linkcheckerrc.5:364
 msgid "Set HTML valid color. Default is B<#3ba557>."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:361
+#: en/linkcheckerrc.5:364
 #, no-wrap
 msgid "[blacklist]"
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:368
+#: en/linkcheckerrc.5:371
 #, no-wrap
 msgid "[xml]"
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:378
+#: en/linkcheckerrc.5:381
 #, no-wrap
 msgid "[gxml]"
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:388
+#: en/linkcheckerrc.5:391
 #, no-wrap
 msgid "[sitemap]"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:398
+#: en/linkcheckerrc.5:401
 #, no-wrap
 msgid "B<priority=>I<FLOAT>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:402
+#: en/linkcheckerrc.5:405
 msgid ""
 "A number between 0.0 and 1.0 determining the priority. The default priority "
 "for the first URL is 1.0, for all child URLs 0.5."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:402
+#: en/linkcheckerrc.5:405
 #, no-wrap
 msgid "B<frequency=>[B<always>|B<hourly>|B<daily>|B<weekly>|B<monthly>|B<yearly>|B<never>]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:405
+#: en/linkcheckerrc.5:408
 msgid "How frequently pages are changing."
 msgstr ""
 
 #. type: SH
-#: en/linkcheckerrc.5:406
+#: en/linkcheckerrc.5:409
 #, no-wrap
 msgid "LOGGER PARTS"
 msgstr ""
 
-#. type: Plain text
+#. type: tbl table
+#: en/linkcheckerrc.5:413
+#, no-wrap
+msgid "B<all>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:413
+#, no-wrap
+msgid "(for all parts)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:414
+#, no-wrap
+msgid "B<id>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:414
+#, no-wrap
+msgid "(a unique ID for each logentry)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:415
+#, no-wrap
+msgid "B<realurl>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:415
+#, no-wrap
+msgid "(the full url link)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:416
+#, no-wrap
+msgid "B<result>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:416
+#, no-wrap
+msgid "(valid or invalid, with messages)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:417
+#, no-wrap
+msgid "B<extern>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:417
+#, no-wrap
+msgid "(1 or 0, only in some logger types reported)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:418
+#, no-wrap
+msgid "B<base>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:418
+#, no-wrap
+msgid "(base href=...)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:419
+#, no-wrap
+msgid "B<name>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:419
+#, no-wrap
+msgid "(E<lt>a href=...E<gt>nameE<lt>/aE<gt> and E<lt>img alt=\"name\"E<gt>)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:420
+#, no-wrap
+msgid "B<parenturl>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:420
+#, no-wrap
+msgid "(if any)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:421
+#, no-wrap
+msgid "B<info>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:421
+#, no-wrap
+msgid "(some additional info, e.g. FTP welcome messages)"
+msgstr ""
+
+#. type: tbl table
 #: en/linkcheckerrc.5:422
 #, no-wrap
-msgid ""
-" B<all>       (for all parts)\n"
-" B<id>        (a unique ID for each logentry)\n"
-" B<realurl>   (the full url link)\n"
-" B<result>    (valid or invalid, with messages)\n"
-" B<extern>    (1 or 0, only in some logger types reported)\n"
-" B<base>      (base href=...)\n"
-" B<name>      (E<lt>a href=...E<gt>nameE<lt>/aE<gt> and E<lt>img "
-"alt=\"name\"E<gt>)\n"
-" B<parenturl> (if any)\n"
-" B<info>      (some additional info, e.g. FTP welcome messages)\n"
-" B<warning>   (warnings)\n"
-" B<dltime>    (download time)\n"
-" B<checktime> (check time)\n"
-" B<url>       (the original url name, can be relative)\n"
-" B<intro>     (the blurb at the beginning, \"starting at ...\")\n"
-" B<outro>     (the blurb at the end, \"found x errors ...\")\n"
+msgid "B<warning>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:422
+#, no-wrap
+msgid "(warnings)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:423
+#, no-wrap
+msgid "B<dltime>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:423
+#, no-wrap
+msgid "(download time)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:424
+#, no-wrap
+msgid "B<checktime>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:424
+#, no-wrap
+msgid "(check time)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:425
+#, no-wrap
+msgid "B<url>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:425
+#, no-wrap
+msgid "(the original url name, can be relative)"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:426
+#, no-wrap
+msgid "B<intro>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:426
+#, no-wrap
+msgid "(the blurb at the beginning, \"starting at ...\")"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:427
+#, no-wrap
+msgid "B<outro>"
+msgstr ""
+
+#. type: tbl table
+#: en/linkcheckerrc.5:427
+#, no-wrap
+msgid "(the blurb at the end, \"found x errors ...\")"
 msgstr ""
 
 #. type: SH
-#: en/linkcheckerrc.5:422
+#: en/linkcheckerrc.5:429
 #, no-wrap
 msgid "MULTILINE"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:426
+#: en/linkcheckerrc.5:433
 msgid ""
 "Some option values can span multiple lines. Each line has to be indented for "
 "that to work. Lines starting with a hash (B<#>) will be ignored, though they "
@@ -2328,48 +2525,48 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:432
+#: en/linkcheckerrc.5:439
 #, no-wrap
 msgid ""
-" ignore=\n"
-"   lconline\n"
-"   bookmark\n"
-"   # a comment\n"
-"   ^mailto:\n"
+"ignore=\n"
+"  lconline\n"
+"  bookmark\n"
+"  # a comment\n"
+"  ^mailto:\n"
 msgstr ""
 
 #. type: SH
-#: en/linkcheckerrc.5:433
+#: en/linkcheckerrc.5:440
 #, no-wrap
 msgid "EXAMPLE"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:436
+#: en/linkcheckerrc.5:444
 #, no-wrap
 msgid ""
-" [output]\n"
-" log=html\n"
-msgstr ""
-
-#. type: Plain text
-#: en/linkcheckerrc.5:439
-#, no-wrap
-msgid ""
-" [checking]\n"
-" threads=5\n"
-msgstr ""
-
-#. type: Plain text
-#: en/linkcheckerrc.5:442
-#, no-wrap
-msgid ""
-" [filtering]\n"
-" ignorewarnings=http-moved-permanent\n"
+"[output]\n"
+"log=html\n"
 msgstr ""
 
 #. type: Plain text
 #: en/linkcheckerrc.5:447
+#, no-wrap
+msgid ""
+"[checking]\n"
+"threads=5\n"
+msgstr ""
+
+#. type: Plain text
+#: en/linkcheckerrc.5:450
+#, no-wrap
+msgid ""
+"[filtering]\n"
+"ignorewarnings=http-moved-permanent\n"
+msgstr ""
+
+#. type: Plain text
+#: en/linkcheckerrc.5:455
 msgid ""
 "All plugins have a separate section. If the section appears in the "
 "configuration file the plugin is enabled.  Some plugins read extra options "
@@ -2377,37 +2574,37 @@ msgid ""
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:448
+#: en/linkcheckerrc.5:456
 #, no-wrap
 msgid "[AnchorCheck]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:450
+#: en/linkcheckerrc.5:458
 msgid "Checks validity of HTML anchors."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:451
+#: en/linkcheckerrc.5:459
 #, no-wrap
 msgid "[LocationInfo]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:454
+#: en/linkcheckerrc.5:462
 msgid ""
 "Adds the country and if possible city name of the URL host as info.  Needs "
 "GeoIP or pygeoip and a local country or city lookup DB installed."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:455
+#: en/linkcheckerrc.5:463
 #, no-wrap
 msgid "[RegexCheck]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:459
+#: en/linkcheckerrc.5:467
 msgid ""
 "Define a regular expression which prints a warning if it matches any content "
 "of the checked link. This applies only to valid pages, so we can get their "
@@ -2415,13 +2612,13 @@ msgid ""
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:459
+#: en/linkcheckerrc.5:467
 #, no-wrap
 msgid "B<warningregex=>I<REGEX>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:464
+#: en/linkcheckerrc.5:472
 msgid ""
 "Use this to check for pages that contain some form of error message, for "
 "example \"This page has moved\" or \"Oracle Application error\". I<REGEX> "
@@ -2429,297 +2626,297 @@ msgid ""
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:468
+#: en/linkcheckerrc.5:476
 #, no-wrap
 msgid "[SslCertificateCheck]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:472
+#: en/linkcheckerrc.5:480
 msgid ""
 "Check SSL certificate expiration date. Only internal https: links will be "
 "checked. A domain will only be checked once to avoid duplicate warnings."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:472
+#: en/linkcheckerrc.5:480
 #, no-wrap
 msgid "B<sslcertwarndays=>I<NUMBER>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:475
+#: en/linkcheckerrc.5:483
 msgid "Configures the expiration warning time in days."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:476
+#: en/linkcheckerrc.5:484
 #, no-wrap
 msgid "[HtmlSyntaxCheck]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:479
+#: en/linkcheckerrc.5:489
 msgid ""
 "Check the syntax of HTML pages with the online W3C HTML validator.  See "
-"http://validator.w3.org/docs/api.html."
+"E<.UR https://validator.w3.org/docs/api.html> E<.UE .>"
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:480
+#: en/linkcheckerrc.5:490
 #, no-wrap
 msgid "[HttpHeaderInfo]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:482
+#: en/linkcheckerrc.5:492
 msgid "Print HTTP headers in URL info."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:482
+#: en/linkcheckerrc.5:492
 #, no-wrap
 msgid "B<prefixes=>I<prefix1>[,I<prefix2>]..."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:486
+#: en/linkcheckerrc.5:496
 msgid ""
 "List of comma separated header prefixes. For example to display all HTTP "
 "headers that start with \"X-\"."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:487
+#: en/linkcheckerrc.5:497
 #, no-wrap
 msgid "[CssSyntaxCheck]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:490
+#: en/linkcheckerrc.5:502
 msgid ""
-"Check the syntax of HTML pages with the online W3C CSS validator.  See "
-"http://jigsaw.w3.org/css-validator/manual.html#expert."
+"Check the syntax of HTML pages with the online W3C CSS validator.  See E<.UR "
+"https://jigsaw.w3.org/css-validator/manual.html#expert> E<.UE .>"
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:491
+#: en/linkcheckerrc.5:503
 #, no-wrap
 msgid "[VirusCheck]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:494
+#: en/linkcheckerrc.5:506
 msgid ""
 "Checks the page content for virus infections with clamav.  A local clamav "
 "daemon must be installed."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:494
+#: en/linkcheckerrc.5:506
 #, no-wrap
 msgid "B<clamavconf=>I<filename>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:497
+#: en/linkcheckerrc.5:509
 msgid "Filename of B<clamd.conf> config file."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:498
+#: en/linkcheckerrc.5:510
 #, no-wrap
 msgid "[PdfParser]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:501
+#: en/linkcheckerrc.5:513
 msgid ""
 "Parse PDF files for URLs to check. Needs the B<pdfminer> Python package "
 "installed."
 msgstr ""
 
 #. type: SS
-#: en/linkcheckerrc.5:502
+#: en/linkcheckerrc.5:514
 #, no-wrap
 msgid "[WordParser]"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:505
+#: en/linkcheckerrc.5:517
 msgid ""
 "Parse Word files for URLs to check. Needs the B<pywin32> Python extension "
 "installed."
 msgstr ""
 
 #. type: SH
-#: en/linkcheckerrc.5:506
+#: en/linkcheckerrc.5:518
 #, no-wrap
 msgid "WARNINGS"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:509
+#: en/linkcheckerrc.5:521
 msgid ""
 "The following warnings are recognized in the 'ignorewarnings' config file "
 "entry:"
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:510
+#: en/linkcheckerrc.5:522
 #, no-wrap
 msgid "B<file-missing-slash>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:513
+#: en/linkcheckerrc.5:525
 msgid "The file: URL is missing a trailing slash."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:513
+#: en/linkcheckerrc.5:525
 #, no-wrap
 msgid "B<file-system-path>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:516
+#: en/linkcheckerrc.5:528
 msgid "The file: path is not the same as the system specific path."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:516
+#: en/linkcheckerrc.5:528
 #, no-wrap
 msgid "B<ftp-missing-slash>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:519
+#: en/linkcheckerrc.5:531
 msgid "The ftp: URL is missing a trailing slash."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:519
+#: en/linkcheckerrc.5:531
 #, no-wrap
 msgid "B<http-cookie-store-error>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:522
+#: en/linkcheckerrc.5:534
 msgid "An error occurred while storing a cookie."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:522
+#: en/linkcheckerrc.5:534
 #, no-wrap
 msgid "B<http-empty-content>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:525
+#: en/linkcheckerrc.5:537
 msgid "The URL had no content."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:525
+#: en/linkcheckerrc.5:537
 #, no-wrap
 msgid "B<mail-no-mx-host>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:528
+#: en/linkcheckerrc.5:540
 msgid "The mail MX host could not be found."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:528
+#: en/linkcheckerrc.5:540
 #, no-wrap
 msgid "B<nntp-no-newsgroup>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:531
+#: en/linkcheckerrc.5:543
 msgid "The NNTP newsgroup could not be found."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:531
+#: en/linkcheckerrc.5:543
 #, no-wrap
 msgid "B<nntp-no-server>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:534
+#: en/linkcheckerrc.5:546
 msgid "No NNTP server was found."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:534
+#: en/linkcheckerrc.5:546
 #, no-wrap
 msgid "B<url-content-size-zero>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:537
+#: en/linkcheckerrc.5:549
 msgid "The URL content size is zero."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:537
+#: en/linkcheckerrc.5:549
 #, no-wrap
 msgid "B<url-content-too-large>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:540
+#: en/linkcheckerrc.5:552
 msgid "The URL content size is too large."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:540
+#: en/linkcheckerrc.5:552
 #, no-wrap
 msgid "B<url-effective-url>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:543
+#: en/linkcheckerrc.5:555
 msgid "The effective URL is different from the original."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:543
+#: en/linkcheckerrc.5:555
 #, no-wrap
 msgid "B<url-error-getting-content>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:546
+#: en/linkcheckerrc.5:558
 msgid "Could not get the content of the URL."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:546
+#: en/linkcheckerrc.5:558
 #, no-wrap
 msgid "B<url-obfuscated-ip>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:549
+#: en/linkcheckerrc.5:561
 msgid "The IP is obfuscated."
 msgstr ""
 
 #. type: TP
-#: en/linkcheckerrc.5:549
+#: en/linkcheckerrc.5:561
 #, no-wrap
 msgid "B<url-whitespace>"
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:552
+#: en/linkcheckerrc.5:564
 msgid "The URL contains leading or trailing whitespace."
 msgstr ""
 
 #. type: Plain text
-#: en/linkcheckerrc.5:555
-msgid "linkchecker(1)"
+#: en/linkcheckerrc.5:567
+msgid "B<linkchecker>(1)"
 msgstr ""

--- a/doc/translations.md
+++ b/doc/translations.md
@@ -1,0 +1,21 @@
+LinkChecker Translations
+========================
+
+Translations for the application are stored in po/.
+Translations for the man pages are stored in doc/.
+
+Application Translations
+------------------------
+
+``linkchecker $ make locale``
+
+is equivalent to:
+
+``linkchecker/po $ make``
+
+Man Page Translations
+---------------------
+
+po4a is used to generate linkchecker.doc.pot, .po files and translated man pages.
+
+``linkchecker/doc $ make po4a``

--- a/linkcheck/plugins/markdowncheck.py
+++ b/linkcheck/plugins/markdowncheck.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Vadym Khokhlov
+# Copyright (C) 2014 Vadym Khokhlov
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/po/Makefile
+++ b/po/Makefile
@@ -2,7 +2,7 @@ XGETTEXT := xgettext
 MSGFMT := msgfmt
 MSGMERGE := msgmerge
 POSOURCES = $(shell find ../linkcheck -name \*.py) \
-	../linkchecker $(python3 -c 'import argparse; print(argparse.__file__)')
+	../linkchecker $(shell python3 -c 'import argparse; print(argparse.__file__)')
 LDIR = ../share/locale
 PACKAGE = linkchecker
 TEMPLATE = $(PACKAGE).pot


### PR DESCRIPTION
Changes to man page format in:
a205a372 ("Update man pages to optimise for both html and man", 2020-04-24)
broke the mapping in doc/de.po, so update the .pot and de.po and then move existing German strings and regenerate the de man pages.

Also some fixes for the application translation generation and a basic explanation of the use of make in a new document translations.md.
