### PR TITLE
Assorted review comments and use python3 for setup.py

### DIFF
--- a/linkcheck/checker/fileurl.py
+++ b/linkcheck/checker/fileurl.py
@@ -71,7 +71,7 @@ def get_os_filename(path):
         path = prepare_urlpath_for_nt(path)
     res = urllib.request.url2pathname(fileutil.path_safe(path))
     if os.name == 'nt' and res.endswith(':') and len(res) == 2:
-        # Work around http://bugs.python.org/issue11474
+        # Work around https://bugs.python.org/issue11474
         res += os.sep
     return res
 

--- a/linkcheck/checker/mailtourl.py
+++ b/linkcheck/checker/mailtourl.py
@@ -137,20 +137,20 @@ class MailtoUrl(urlbase.UrlBase):
     def check_email_syntax(self, mail):
         """Check email syntax. The relevant RFCs:
         - How to check names (memo):
-          http://tools.ietf.org/html/rfc3696
+          https://tools.ietf.org/html/rfc3696
         - Email address syntax
-          http://tools.ietf.org/html/rfc2822
+          https://tools.ietf.org/html/rfc2822
         - SMTP protocol
-          http://tools.ietf.org/html/rfc5321#section-4.1.3
+          https://tools.ietf.org/html/rfc5321#section-4.1.3
         - IPv6
-          http://tools.ietf.org/html/rfc4291#section-2.2
+          https://tools.ietf.org/html/rfc4291#section-2.2
         - Host syntax
-          http://tools.ietf.org/html/rfc1123#section-2
+          https://tools.ietf.org/html/rfc1123#section-2
         """
         # length checks
 
         # restrict email length to 256 characters
-        # http://www.rfc-editor.org/errata_search.php?eid=1003
+        # https://www.rfc-editor.org/errata_search.php?eid=1003
         if len(mail) > 256:
             self.set_result(
                 _(
@@ -210,7 +210,7 @@ class MailtoUrl(urlbase.UrlBase):
 
         # local part syntax check
 
-        # Rules taken from http://tools.ietf.org/html/rfc3696#section-3
+        # Rules taken from https://tools.ietf.org/html/rfc3696#section-3
         if is_quoted(local):
             if is_missing_quote(local):
                 self.set_result(

--- a/linkcheck/configuration/confparse.py
+++ b/linkcheck/configuration/confparse.py
@@ -233,9 +233,11 @@ class LCConfigParser(RawConfigParser):
         if fileutil.is_accessable_by_others(fn):
             log.warn(
                 LOG_CHECK,
-                "The configuration file %s contains password information (in"
-                " section [%s] and options %s) and the file is readable by"
-                " others. Please make the file only readable by you.",
+                _(
+                    "The configuration file %s contains password information (in"
+                    " section [%s] and options %s) and the file is readable by"
+                    " others. Please make the file only readable by you."
+                ),
                 fn,
                 section,
                 fields,

--- a/linkcheck/configuration/confparse.py
+++ b/linkcheck/configuration/confparse.py
@@ -248,9 +248,8 @@ class LCConfigParser(RawConfigParser):
                 log.warn(
                     LOG_CHECK,
                     _(
-                        "See http://support.microsoft.com/kb/308419 for"
-                        " more info on setting file permissions."
-                    ),
+                        "See %(url)s for more info on setting file permissions."
+                    ) % {"url": "https://support.microsoft.com/kb/308419"}
                 )
 
     def read_filtering_config(self):

--- a/linkcheck/logger/blacklist.py
+++ b/linkcheck/logger/blacklist.py
@@ -18,7 +18,7 @@ A blacklist logger.
 """
 
 import os
-import codecs
+
 from linkcheck.configuration import get_user_data
 from . import _Logger
 
@@ -76,9 +76,8 @@ class BlacklistLogger(_Logger):
         """
         Read a previously stored blacklist from file fd.
         """
-        with codecs.open(
-            self.filename, 'r', self.output_encoding, self.codec_errors
-        ) as fd:
+        with open(self.filename, 'r', encoding=self.output_encoding,
+                  errors=self.codec_errors) as fd:
             for line in fd:
                 line = line.rstrip()
                 if line.startswith('#') or not line:

--- a/linkcheck/logger/dot.py
+++ b/linkcheck/logger/dot.py
@@ -15,7 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 A DOT graph format logger. The specification has been taken from
-http://www.graphviz.org/doc/info/lang.html
+https://www.graphviz.org/doc/info/lang.html
 """
 from .graph import _GraphLogger
 

--- a/linkcheck/logger/html.py
+++ b/linkcheck/logger/html.py
@@ -194,7 +194,7 @@ class HtmlLogger(_Logger):
             "<tr><td>"
             + self.part("parenturl")
             + '</td><td><a target="top" href="'
-            + url_data.parent_url
+            + html.escape(url_data.parent_url)
             + '">'
             + html.escape(url_data.parent_url)
             + "</a>"
@@ -231,7 +231,7 @@ class HtmlLogger(_Logger):
             + self.part("realurl")
             + "</td><td>"
             + '<a target="top" href="'
-            + url_data.url
+            + html.escape(url_data.url)
             + '">'
             + html.escape(url_data.url)
             + "</a></td></tr>"

--- a/linkcheck/logger/html.py
+++ b/linkcheck/logger/html.py
@@ -26,10 +26,10 @@ from .. import strformat, configuration
 
 
 # ss=1 enables show source
-validate_html = "http://validator.w3.org/check?ss=1&amp;uri=%(uri)s"
+validate_html = "https://validator.w3.org/check?ss=1&amp;uri=%(uri)s"
 # options are the default
 validate_css = (
-    "http://jigsaw.w3.org/css-validator/validator?"
+    "https://jigsaw.w3.org/css-validator/validator?"
     "uri=%(uri)s&amp;warning=1&amp;profile=css2&amp;usermedium=all"
 )
 

--- a/linkcheck/logger/sitemapxml.py
+++ b/linkcheck/logger/sitemapxml.py
@@ -34,7 +34,7 @@ HTML_TYPES = ('text/html', "application/xhtml+xml")
 
 
 class SitemapXmlLogger(xmllog._XMLLogger):
-    """Sitemap XML output according to http://www.sitemaps.org/protocol.html
+    """Sitemap XML output according to https://www.sitemaps.org/protocol.html
     """
 
     LoggerName = 'sitemap'

--- a/linkcheck/plugins/locationinfo.py
+++ b/linkcheck/plugins/locationinfo.py
@@ -91,7 +91,7 @@ if geoip_dat:
     else:
         def get_geoip_record(host):
             return {
-                    'country_name': geoip.country_name_by_name(host)
+                'country_name': geoip.country_name_by_name(host),
             }
 
 

--- a/linkcheck/plugins/syntaxchecks.py
+++ b/linkcheck/plugins/syntaxchecks.py
@@ -45,7 +45,7 @@ class W3Timer:
 
 class HtmlSyntaxCheck(_ContentPlugin):
     """Check the syntax of HTML pages with the online W3C HTML validator.
-    See http://validator.w3.org/docs/api.html.
+    See https://validator.w3.org/docs/api.html.
     """
 
     def __init__(self, config):
@@ -63,7 +63,7 @@ class HtmlSyntaxCheck(_ContentPlugin):
         session = url_data.session
         try:
             body = {'uri': url_data.url, 'output': 'soap12'}
-            response = session.post('http://validator.w3.org/check', data=body)
+            response = session.post('https://validator.w3.org/check', data=body)
             response.raise_for_status()
             if response.headers.get('x-w3c-validator-status', 'Invalid') == 'Valid':
                 url_data.add_info("W3C Validator: %s" % _("valid HTML syntax"))
@@ -79,7 +79,7 @@ class HtmlSyntaxCheck(_ContentPlugin):
 
 class CssSyntaxCheck(_ContentPlugin):
     """Check the syntax of HTML pages with the online W3C CSS validator.
-    See http://jigsaw.w3.org/css-validator/manual.html#expert.
+    See https://jigsaw.w3.org/css-validator/manual.html#expert.
     """
 
     def __init__(self, config):
@@ -96,7 +96,7 @@ class CssSyntaxCheck(_ContentPlugin):
         self.timer.check_w3_time()
         session = url_data.session
         try:
-            url = 'http://jigsaw.w3.org/css-validator/validator'
+            url = 'https://jigsaw.w3.org/css-validator/validator'
             params = {
                 'uri': url_data.url,
                 'warning': '2',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 # Copyright (C) 2000-2014 Bastian Kleineidam
 #
 # This program is free software; you can redistribute it and/or modify

--- a/tests/checker/__init__.py
+++ b/tests/checker/__init__.py
@@ -18,7 +18,6 @@ Define standard test support classes funtional for LinkChecker tests.
 """
 import os
 import re
-import codecs
 import difflib
 import unittest
 import linkcheck.checker
@@ -235,7 +234,7 @@ class LinkCheckTest(unittest.TestCase):
         if hasattr(self, "port"):
             d["port"] = self.port
         # all result files are encoded in utf-8
-        with codecs.open(resultfile, "r", "utf-8") as f:
+        with open(resultfile, "r", encoding="utf-8") as f:
             return [
                 line.rstrip("\r\n") % d
                 for line in f

--- a/tests/test_po.py
+++ b/tests/test_po.py
@@ -34,6 +34,8 @@ def get_pofiles():
         pofiles = []
         pofiles.extend(glob.glob("po/*.po"))
         pofiles.extend(glob.glob("doc/*.po"))
+    if not pofiles:
+        raise Exception("No .po files found")
     return pofiles
 
 
@@ -56,15 +58,15 @@ class TestGTranslator(unittest.TestCase):
     def test_gtranslator(self):
         """Test all pofiles for GTranslator brokenness."""
         for f in get_pofiles():
-            with open(f, "rb") as fd:
+            with open(f) as fd:
                 self.check_file(fd, f)
 
     def check_file(self, fd, f):
         """Test for GTranslator broken syntax."""
         for line in fd:
-            if line.strip().startswith(b"#"):
+            if line.strip().startswith("#"):
                 continue
             self.assertFalse(
-                b"\xc2\xb7" in line,
-                "Broken GTranslator copy/paste in %r:\n%r" % (f, line),
+                "·" in line,
+                "Broken GTranslator copy/paste in %r:\n%s" % (f, line),
             )

--- a/tests/test_po.py
+++ b/tests/test_po.py
@@ -58,7 +58,7 @@ class TestGTranslator(unittest.TestCase):
     def test_gtranslator(self):
         """Test all pofiles for GTranslator brokenness."""
         for f in get_pofiles():
-            with open(f) as fd:
+            with open(f, encoding="UTF-8") as fd:
                 self.check_file(fd, f)
 
     def check_file(self, fd, f):


### PR DESCRIPTION
Various review comments from #439 and before.

Plus use python3 in setup.py. I think this might save some reports  similar to issues we have seen - avoid an error for an Ubuntu 20.04 user with Python 2 installed who runs `./setup.py`.
