### PR TITLE
Replace KDE 3 proxy support with KDE 5 support

### DIFF
--- a/linkcheck/configuration/__init__.py
+++ b/linkcheck/configuration/__init__.py
@@ -630,7 +630,7 @@ def add_kde_setting(key, value, data):
         elif value == "false":
             value = False
         else:
-            value = int(value)
+            value = int(value) != 0
         data["reversed_bypass"] = value
     elif key == "NoProxyFor":
         data["ignore_hosts"] = split_hosts(value)

--- a/linkcheck/configuration/__init__.py
+++ b/linkcheck/configuration/__init__.py
@@ -542,14 +542,12 @@ def get_kde_config_dir():
     if not home:
         log.debug(LOG_CHECK, "KDEHOME and HOME not set")
         return
-    if shutil.which("kde4-config"):
-        kde_config_dir = os.path.join(home, ".kde4", "share", "config")
-    else:
-        # KDE 5
-        kde_config_dir = os.path.join(home, ".config")
+    kde_config_dir = os.path.join(home, ".config")
     if not os.path.exists(kde_config_dir):
-        log.debug(LOG_CHECK, "%s does not exist" % kde_config_dir)
-        return
+        kde_config_dir = os.path.join(home, ".kde4", "share", "config")
+        if not os.path.exists(kde_config_dir):
+            log.debug(LOG_CHECK, "%s does not exist" % kde_config_dir)
+            return
     return kde_config_dir
 
 

--- a/linkcheck/configuration/__init__.py
+++ b/linkcheck/configuration/__init__.py
@@ -543,44 +543,18 @@ def get_kde_ftp_proxy():
 
 def get_kde_config_dir():
     """Return KDE configuration directory or None if not found."""
-    kde_home = get_kde_home_dir()
-    if not kde_home:
-        # could not determine the KDE home directory
-        return
-    return kde_home_to_config(kde_home)
-
-
-def kde_home_to_config(kde_home):
-    """Add subdirectories for config path to KDE home directory."""
-    return os.path.join(kde_home, "share", "config")
-
-
-def get_kde_home_dir():
-    """Return KDE home directory or None if not found."""
     if os.environ.get("KDEHOME"):
-        kde_home = os.path.abspath(os.environ["KDEHOME"])
+        home = os.environ.get("KDEHOME")
     else:
         home = os.environ.get("HOME")
-        if not home:
-            # $HOME is not set
-            return
-        kde3_home = os.path.join(home, ".kde")
-        kde4_home = os.path.join(home, ".kde4")
-        if shutil.which("kde4-config"):
-            # kde4
-            kde3_file = kde_home_to_config(kde3_home)
-            kde4_file = kde_home_to_config(kde4_home)
-            if os.path.exists(kde4_file) and os.path.exists(kde3_file):
-                if fileutil.get_mtime(kde4_file) >= fileutil.get_mtime(kde3_file):
-                    kde_home = kde4_home
-                else:
-                    kde_home = kde3_home
-            else:
-                kde_home = kde4_home
-        else:
-            # kde3
-            kde_home = kde3_home
-    return kde_home if os.path.exists(kde_home) else None
+    if not home:
+        return
+    if shutil.which("kde4-config"):
+        kde_config_dir = os.path.join(home, ".kde4", "share", "config")
+    else:
+        # KDE 5
+        kde_config_dir = os.path.join(home, ".config")
+    return kde_config_dir if os.path.exists(kde_config_dir) else None
 
 
 loc_ro = re.compile(r"\[.*\]$")
@@ -590,6 +564,7 @@ loc_ro = re.compile(r"\[.*\]$")
 def read_kioslaverc(kde_config_dir):
     """Read kioslaverc into data dictionary."""
     data = {}
+    in_proxy_settings = False
     filename = os.path.join(kde_config_dir, "kioslaverc")
     with open(filename) as fd:
         # First read all lines into dictionary since they can occur
@@ -648,7 +623,13 @@ def add_kde_setting(key, value, data):
     elif key == "ftpProxy":
         add_kde_proxy("ftp_proxy", value, data)
     elif key == "ReversedException":
-        data["reversed_bypass"] = bool(value == "true" or int(value))
+        if value == "true":
+            value = True
+        elif value == "false":
+            value = False
+        else:
+            value = int(value)
+        data["reversed_bypass"] = value
     elif key == "NoProxyFor":
         data["ignore_hosts"] = split_hosts(value)
     elif key == "AuthMode":


### PR DESCRIPTION
KDE 3 was superseded in 2008.

KDE 4 uses: ${HOME}/.kde4/share/config/kioslaverc
KDE 5 (Kubuntu) uses: ${HOME}/.config/kioslaverc

Default ReversedException is false
