### PR TITLE
Update Mac installation instructions with Homebrew pip and macOS

### DIFF
--- a/doc/install.txt
+++ b/doc/install.txt
@@ -20,9 +20,10 @@ Python from the Microsoft Store does include pip_, but installing
 within Windows Subsystem for Linux (WSL) is the preferred option:
 https://docs.microsoft.com/en-us/windows/python/beginners
 
-Setup for Mac OS X
+Setup for macOS
 ------------------
-Obtain ``get-pip.py`` to install pip_ (untested):
+Python from Homebrew includes pip_. Otherwise ``get-pip.py`` can be used to
+install pip_ (untested):
 https://pip.pypa.io/en/stable/installing/
 
 Setup for GNU/Linux


### PR DESCRIPTION
The first release of macOS was in 2016.