### PR TITLE
Fix anchor checking

### DIFF
--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -363,11 +363,13 @@ class UrlBase:
 
     def set_cache_url(self):
         """Set the URL to be used for caching."""
-        # remove anchor from cached target url since we assume
-        # URLs with different anchors to have the same content
-        self.cache_url = urlutil.urlunsplit(self.urlparts[:4] + [''])
-        if self.cache_url is not None:
-            assert isinstance(self.cache_url, str), repr(self.cache_url)
+        if "AnchorCheck" in self.aggregate.config["enabledplugins"]:
+            self.cache_url = self.url
+        else:
+            # remove anchor from cached target url since we assume
+            # URLs with different anchors to have the same content
+            self.cache_url = urlutil.urlunsplit(self.urlparts[:4] + [''])
+        log.debug(LOG_CHECK, "cache_url '%s'", self.cache_url)
 
     def check_syntax(self):
         """

--- a/tests/checker/data/http_anchor.html
+++ b/tests/checker/data/http_anchor.html
@@ -1,0 +1,4 @@
+<p id="good">
+<a href="http_anchor.html">a</a>
+<a href="http_anchor.html#good">a_good</a>
+<a href="http_anchor.html#bad">a_bad</a>

--- a/tests/checker/data/http_anchor.html.result
+++ b/tests/checker/data/http_anchor.html.result
@@ -1,0 +1,17 @@
+url http://localhost:%(port)d/%(datadir)s/http_anchor.html
+cache key http://localhost:%(port)d/%(datadir)s/http_anchor.html
+real url http://localhost:%(port)d/%(datadir)s/http_anchor.html
+valid
+
+url http_anchor.html#bad
+cache key http://localhost:%(port)d/%(datadir)s/http_anchor.html#bad
+real url http://localhost:%(port)d/%(datadir)s/http_anchor.html#bad
+name a_bad
+warning Anchor `bad' not found. Available anchors: `good'.
+valid
+
+url http_anchor.html#good
+cache key http://localhost:%(port)d/%(datadir)s/http_anchor.html#good
+real url http://localhost:%(port)d/%(datadir)s/http_anchor.html#good
+name a_good
+valid

--- a/tests/checker/test_anchor.py
+++ b/tests/checker/test_anchor.py
@@ -17,6 +17,7 @@
 Test html anchor parsing and checking.
 """
 from . import LinkCheckTest
+from .httpserver import HttpServerTest
 
 
 class TestAnchor(LinkCheckTest):
@@ -38,3 +39,13 @@ class TestAnchor(LinkCheckTest):
             "valid",
         ]
         self.direct(urlanchor, resultlines, confargs=confargs)
+
+
+class TestHttpAnchor(HttpServerTest):
+    """
+    Test checking of HTML pages containing links to anchors served over http.
+    """
+
+    def test_anchor_html(self):
+        confargs = dict(enabledplugins=["AnchorCheck"], recursionlevel=1)
+        self.file_test("http_anchor.html", confargs=confargs)


### PR DESCRIPTION
Query and fragment URL parts for filesystem URLs are ignored, therefore
test over http.

---

First a new test, let's see it fail.

Closes #460.
