### PR TITLE
Remove defaults from lc_cgi.checklink()

### DIFF
--- a/linkcheck/lc_cgi.py
+++ b/linkcheck/lc_cgi.py
@@ -18,7 +18,6 @@ Functions used by the WSGI script.
 """
 
 import html
-import os
 import threading
 import locale
 import re
@@ -137,7 +136,7 @@ def encode(s):
     return s.encode(HTML_ENCODING, 'ignore')
 
 
-def checklink(form=None, env=os.environ):
+def checklink(form, env):
     """Validates the CGI form and checks the given links."""
     if form is None:
         form = {}

--- a/tests/test_cgi.py
+++ b/tests/test_cgi.py
@@ -53,7 +53,7 @@ class TestWsgi(unittest.TestCase):
 
     def test_checklink(self):
         form = dict(url="http://www.example.com/", level="0")
-        checklink(form)
+        checklink(form, {})
 
     def test_application(self):
         form = dict(url="http://www.example.com/", level="0")


### PR DESCRIPTION
Only called from application() with arguments. Causes local environment
to be embedded in documentation when using Sphinx autodoc.