### PR TITLE
Fix status=0 setting being ignored

### DIFF
--- a/linkcheck/configuration/__init__.py
+++ b/linkcheck/configuration/__init__.py
@@ -202,7 +202,7 @@ class Configuration(dict):
         self["warnings"] = True
         self["fileoutput"] = []
         self['output'] = 'text'
-        self["status"] = False
+        self["status"] = True
         self["status_wait_seconds"] = 5
         self['logger'] = None
         self.loggers = {}

--- a/linkchecker
+++ b/linkchecker
@@ -337,8 +337,8 @@ group.add_argument(
 group.add_argument(
     "--no-status",
     action="store_false",
+    default=None,
     dest="status",
-    default=True,
     help=_("Do not print check status messages."),
 )
 group.add_argument(
@@ -656,7 +656,7 @@ if options.quiet:
     config["logger"] = config.logger_new("none")
 if options.recursionlevel is not None:
     config["recursionlevel"] = options.recursionlevel
-if options.status:
+if options.status is not None:
     config["status"] = options.status
 if options.threads is not None:
     if options.threads < 1:


### PR DESCRIPTION
- Set the correct default for the setting in configuration.Configuration
- Detect when the argument is not passed by setting the default to None
  (store_false sets the default to True)

---

Closes #52 
