### PR TITLE
Fix critical exception when parsing a URL with a ]

### DIFF
--- a/linkcheck/checker/const.py
+++ b/linkcheck/checker/const.py
@@ -27,6 +27,7 @@ from dns.exception import DNSException
 # Catch these exception on syntax checks.
 ExcSyntaxList = [
     LinkCheckerError,
+    ValueError,
 ]
 
 # Catch these exceptions on content and connect checks. All other


### PR DESCRIPTION
e.g.:

`<a href="http://localhost]">square</a>`

---

Closes #43.
