### PR TITLE
Don't translate "Retry-After" server header field

### DIFF
--- a/linkcheck/checker/httpurl.py
+++ b/linkcheck/checker/httpurl.py
@@ -304,7 +304,7 @@ class HttpUrl(internpaturl.InternPatternUrl, proxysupport.ProxySupport):
             if self.url_connection.status_code == 429:
                 self.add_warning(
                     "Rate limited (Retry-After: %s)"
-                    % self.headers.get(_("Retry-After")),
+                    % self.headers.get("Retry-After"),
                     tag=WARN_URL_RATE_LIMITED,
                 )
 


### PR DESCRIPTION
It is defined in RFC 7231.

---

Closes  #449.
