### PR TITLE
MS Windows Python 3.7 and MS Store compatibility

### DIFF
--- a/doc/examples/windows.bat
+++ b/doc/examples/windows.bat
@@ -1,4 +1,4 @@
 @echo off
-:: example using linkchecker on windows, logging to html
-set PYDIR=c:\python26
-%PYDIR%\python.exe %PYDIR%\scripts\linkchecker -Fhtml http://www.example.com
+:: Do replace the for loop with setting SCRIPTSDIR to the literal path
+for /f "delims=" %%i in ('python -c "import site; print(site.getusersitepackages().replace('site-packages', 'Scripts'))"') do set SCRIPTSDIR=%%i
+python %SCRIPTSDIR%\linkchecker %*

--- a/linkcheck/checker/fileurl.py
+++ b/linkcheck/checker/fileurl.py
@@ -54,7 +54,7 @@ def prepare_urlpath_for_nt(path):
 
 def get_nt_filename(path):
     """Return case sensitive filename for NT path."""
-    unc, rest = os.path.splitunc(path)
+    unc, rest = os.path.splitdrive(path)
     head, tail = os.path.split(rest)
     if not tail:
         return path

--- a/tests/checker/test_noproxy.py
+++ b/tests/checker/test_noproxy.py
@@ -16,7 +16,8 @@
 """
 Test proxy handling.
 """
-from test.support import EnvironmentVarGuard
+
+from unittest.mock import patch
 
 from . import httpserver
 
@@ -25,10 +26,11 @@ class TestProxy(httpserver.HttpServerTest):
     """Test no_proxy env var handling."""
 
     def test_noproxy(self):
-        # set env vars
-        with EnvironmentVarGuard() as env:
-            env.set("http_proxy", "http://example.org:8877")
-            env.set("no_proxy", "localhost:%d" % self.port)
+        with patch.dict("os.environ",
+                        {
+                            "http_proxy": "http://example.org:8877",
+                            "no_proxy": "localhost:%d" % self.port,
+                        }):
             self.noproxy_test()
 
     def noproxy_test(self):


### PR DESCRIPTION
os.path.splitunc() removed in Python 3.7.

https://docs.python.org/3/whatsnew/3.7.html#api-and-feature-removals
