### PR TITLE
Document and test Sphinx documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: python
 python:
   - "3.5"
@@ -15,6 +16,25 @@ jobs:
     - name: check-manifest
       env: TOXENV=check-manifest
       before_script:
+      after_success:
+    - name: sphinx
+      python: "3.6"
+      addons:
+        apt:
+          packages:
+            - graphviz
+            - mandoc
+      install:
+        - pip install -r requirements.txt
+        - pip install Sphinx sphinx-epytext sphinx-intl sphinx-rtd-theme
+      before_script:
+        - python3.6 setup.py build
+      script:
+        - make -C doc code
+        - make -C doc html
+        - make -C doc locale
+        - make -C doc man
+        - make -C doc check
       after_success:
 # command to install dependencies
 addons:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -28,7 +28,6 @@ check:
 clean:
 	rm -rf src/_build; \
 	rm -rf src/code/linkcheck; \
-	rm -rf html; \
-	rm -rf man
+	rm -rf html
 
 .PHONY: check clean html locale man

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -1,0 +1,69 @@
+LinkChecker Documentation
+=========================
+
+LinkChecker is documented with man pages and HTML that is used for the project web site.
+Both are generated using Sphinx, with Makefiles provided to simplify the process.
+
+Sources are found in doc/src. Stand-alone .rst files from doc/ are also included.
+
+In addition to Sphinx the dependencies for building the documentation are:
+
+graphviz
+
+sphinx_epytext
+
+sphinx_rtd_theme
+
+
+Man Pages
+---------
+
+Source files are in doc/src/man.
+
+The pages can be built with:
+
+``linkchecker/doc $ make man``
+
+The files are saved in doc/man.
+
+See translations.md for information about creating localised man pages.
+
+Published man pages are included in the LinkChecker repository.
+
+
+HTML
+----
+
+``doc/src/code/index.rst`` gives an overview of the LinkChecker code, optionally a navigable
+copy of the LinkChecker source can be created with:
+
+``linkchecker/doc $ make code``
+
+Build the HTML files with:
+
+``linkchecker/doc $ make html``
+
+The files are saved in doc/html.
+
+
+Publishing the Web Site
+-----------------------
+
+The Web Site is hosted by GitHub Pages from the docs/ directory of the gh-pages branch.
+
+/docs is a fixed GitHub pages location and contains ``.nojekyll``.
+
+To create a topic branch with updated documentation suitable for a PR:
+
+    git checkout master
+
+    ./setup.py build  # for copyright, author and version info
+    make -C doc code
+    make -C doc html
+
+    git checkout -b <branch> gh-pages
+
+    rm -rf docs/*
+    cp -a doc/html/* docs/
+
+    git commit -a -m "Update documentation"


### PR DESCRIPTION
`make -C doc check` to check the man pages was already present, I switched it to use mandoc - I could have documented why better, man-db was outputting warnings which it wasn't possible to do anything about. Maybe the whole idea of the check is a bit redundant now that they are being generated for us, but it doesn't cost much.

I put the whole check in Travis, as well as mandoc it does use the graphviz deb.
