### PR TITLE
Correct documentation of aborttimeout, no matching option

### DIFF
--- a/doc/man/de/linkcheckerrc.5
+++ b/doc/man/de/linkcheckerrc.5
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "LINKCHECKERRC" "5" "September 14, 2020" "2020-09-14" "LinkChecker"
+.TH "LINKCHECKERRC" "5" "Oktober 02, 2020" "2020-10-02" "LinkChecker"
 .SH NAME
 linkcheckerrc \- Konfigurationsdatei für LinkChecker
 .
@@ -108,7 +108,7 @@ Command line option: none
 .SS filtering
 .INDENT 0.0
 .TP
-\fBignore=\fP\fIREGEX\fP (MULTILINE)
+\fBignore=\fP\fIREGEX\fP (\fI\%MULTILINE\fP)
 Prüfe lediglich die Syntax von URLs, welche dem angegebenen regulären Ausdruck entsprechen. Kommandozeilenoption: \fB\-\-ignore\-url\fP
 .TP
 \fBignorewarnings=\fP\fINAME\fP[\fB,\fP\fINAME\fP\&...]
@@ -117,7 +117,7 @@ Ignoriere die kommagetrennte Liste von Warnungen. Siehe \fI\%WARNINGS\fP für di
 \fBinternlinks=\fP\fIREGEX\fP
 Regulärer Ausdruck, um mehr URLs als interne Verknüpfungen hinzuzufügen. Standard ist dass URLs der Kommandozeile als intern gelten. Kommandozeilenoption: none
 .TP
-\fBnofollow=\fP\fIREGEX\fP (MULTILINE)
+\fBnofollow=\fP\fIREGEX\fP (\fI\%MULTILINE\fP)
 Prüfe URLs die auf den regulären Ausdruck zutreffen, aber führe keine Rekursion durch. Kommandozeilenoption: \fB\-\-no\-follow\-url\fP
 .TP
 \fBcheckextern=\fP[\fB0\fP|\fB1\fP]

--- a/doc/man/de/linkcheckerrc.5
+++ b/doc/man/de/linkcheckerrc.5
@@ -64,7 +64,7 @@ Setze den Timeout für TCP\-Verbindungen in Sekunden. Der Standard Timeout ist 6
 Time to wait for checks to finish after the user aborts the first
 time (with Ctrl\-C or the abort button). The default abort timeout is
 300 seconds.
-Command line option: \fB\-\-timeout\fP
+Command line option: none
 .TP
 \fBuseragent=\fP\fISTRING\fP
 Gibt den User\-Agent an, der zu HTTP\-Servern geschickt wird, z.B. "Mozilla/4.0". Der Standard ist "LinkChecker/X.Y", wobei X.Y die aktuelle Version von LinkChecker ist. Kommandozeilenoption: \fB\-\-user\-agent\fP

--- a/doc/man/en/linkcheckerrc.5
+++ b/doc/man/en/linkcheckerrc.5
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "LINKCHECKERRC" "5" "September 25, 2020" "2020-09-25" "LinkChecker"
+.TH "LINKCHECKERRC" "5" "October 02, 2020" "2020-10-02" "LinkChecker"
 .SH NAME
 linkcheckerrc \- configuration file for LinkChecker
 .
@@ -83,7 +83,7 @@ Command line option: \fB\-\-timeout\fP
 Time to wait for checks to finish after the user aborts the first
 time (with Ctrl\-C or the abort button). The default abort timeout is
 300 seconds.
-Command line option: \fB\-\-timeout\fP
+Command line option: none
 .TP
 \fBuseragent=\fP\fISTRING\fP
 Specify the User\-Agent string to send to the HTTP server, for

--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -53,7 +53,7 @@ checking
     Time to wait for checks to finish after the user aborts the first
     time (with Ctrl-C or the abort button). The default abort timeout is
     300 seconds.
-    Command line option: :option:`--timeout`
+    Command line option: none
 **useragent=**\ *STRING*
     Specify the User-Agent string to send to the HTTP server, for
     example "Mozilla/4.0". The default is "LinkChecker/X.Y" where X.Y is


### PR DESCRIPTION
```
$ grep -rn aborttimeout linkcheck
linkcheck/configuration/confparse.py:167:        self.read_int_option(section, "aborttimeout", min=1)
linkcheck/configuration/__init__.py:184:        self["aborttimeout"] = 300
linkcheck/director/aggregator.py:173:            timeout=strformat.strduration_long(self.config["aborttimeout"]),
linkcheck/director/aggregator.py:200:        timeout = self.config["aborttimeout"]

config["aborttimeout"] is only set from aborttimeout and is the only
value used by Aggregate.abort().
```
---

First some missed multiline hyperlinks in German linkcheckerrc(5) from previous commit.
