### PR TITLE
Automatically publish documentation on GitHub Pages

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -1,0 +1,39 @@
+name: Publish LinkChecker Documentation on GitHub Pages
+
+on:
+  push:
+    branches: ["master"]
+
+jobs:
+  run:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Ubuntu packages
+        run: sudo apt install graphviz
+
+      # Ensure sphinx-autogen is installed in PATH
+      - name: Setup Python
+        uses: actions/setup-python@v2
+
+      - name: Install Python packages
+        run: >
+            pip install dnspython beautifulsoup4 pyxdg requests \
+                        sphinx sphinx_epytext sphinx_rtd_theme
+
+      - name: Build
+        run: |
+            python3 setup.py build
+            make -C doc code
+            make -C doc html
+
+      - name: Publish
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./doc/html
+          destination_dir: docs
+          commit_message: ${{ github.event.head_commit.message }}

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -53,7 +53,10 @@ The Web Site is hosted by GitHub Pages from the docs/ directory of the gh-pages 
 
 /docs is a fixed GitHub pages location and contains ``.nojekyll``.
 
-To create a topic branch with updated documentation suitable for a PR:
+When updates to LinkChecker are pushed, the web site is built and published
+automatically by a GitHub action ``.github/workflows/publish-pages.yml``.
+
+For information, a manual process to build and publish the web site would look like:
 
     git checkout master
 


### PR DESCRIPTION
To save the separate PRs for gh-pages with massive diffs.

Uses https://github.com/peaceiris/actions-gh-pages to do the publishing.