### PR TITLE
Publish documentation to the root of gh-pages

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -35,5 +35,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./doc/html
-          destination_dir: docs
           commit_message: ${{ github.event.head_commit.message }}

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -55,18 +55,3 @@ The Web Site is hosted by GitHub Pages from the docs/ directory of the gh-pages 
 
 When updates to LinkChecker are pushed, the web site is built and published
 automatically by a GitHub action ``.github/workflows/publish-pages.yml``.
-
-For information, a manual process to build and publish the web site would look like:
-
-    git checkout master
-
-    ./setup.py build  # for copyright, author and version info
-    make -C doc code
-    make -C doc html
-
-    git checkout -b <branch> gh-pages
-
-    rm -rf docs/*
-    cp -a doc/html/* docs/
-
-    git commit -a -m "Update documentation"

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -14,6 +14,13 @@ sphinx_epytext
 
 sphinx_rtd_theme
 
+Configuration
+-------------
+
+Before building either man pages or HTML, generate ``_LinkChecker_configdata.py``
+containing copyright, author and version with:
+
+``linkchecker $ ./setup.py build``
 
 Man Pages
 ---------


### PR DESCRIPTION
This gives the Action full control of the branch, it will wipe out anything else e.g. the .gitignore (that isn't needed though if not building in the same repository).

Before merging this I will push a manual commit to gh-pages moving the existing files to root, and point the GitHub pages to the root directory in the project configuration.
