### PR TITLE
Unhandled LookupError in robotparser2.py

### DIFF
--- a/linkcheck/robotparser2.py
+++ b/linkcheck/robotparser2.py
@@ -123,6 +123,9 @@ class RobotFileParser:
             # no network or other failure
             self.allow_all = True
             log.debug(LOG_CHECK, "%r allow all (request error)", self.url)
+        except LookupError:
+            self.allow_all = True
+            log.debug(LOG_CHECK, "%r allow all (lookup error)", self.url)
 
     def _add_entry(self, entry):
         """Add a parsed entry to entry list.


### PR DESCRIPTION
Sites presenting an invalid content-type character set raise a LookupError exception.

For an example, see the single link on [this page I've prepared](http://www-personal.umich.edu/~bertrama/linkchecker/index.html).