### PR TITLE
Better handling for link rel dns-prefetch and preconnect

### DIFF
--- a/linkcheck/htmlutil/linkparse.py
+++ b/linkcheck/htmlutil/linkparse.py
@@ -157,7 +157,8 @@ class LinkFinder:
                 base = self.base_ref
             # note: value can be None
             value = attrs.get(attr)
-            if tag == 'link' and ('dns-prefetch' in attrs.get('rel') or 'preconnect' in attrs.get('rel')):
+            rel = attrs.get('rel', '').lower()
+            if tag == 'link' and ('dns-prefetch' in rel or 'preconnect' in rel):
                 if ':' in value:
                     value = value.split(':', 1)[1]
                 value = 'dns:' + value.rstrip('/')

--- a/linkcheck/htmlutil/linkparse.py
+++ b/linkcheck/htmlutil/linkparse.py
@@ -157,10 +157,10 @@ class LinkFinder:
                 base = self.base_ref
             # note: value can be None
             value = attrs.get(attr)
-            if tag == 'link' and attrs.get('rel') == 'dns-prefetch':
+            if tag == 'link' and ('dns-prefetch' in attrs.get('rel') or 'preconnect' in attrs.get('rel')):
                 if ':' in value:
                     value = value.split(':', 1)[1]
-                value = 'dns:' + value.rstrip('/')
+                value = 'dns:' + value.strip('/')
             # parse tag for URLs
             self.parse_tag(tag, attr, value, name, base, lineno, column)
         log.debug(LOG_CHECK, "LinkFinder finished tag %s", tag)

--- a/linkcheck/htmlutil/linkparse.py
+++ b/linkcheck/htmlutil/linkparse.py
@@ -160,7 +160,7 @@ class LinkFinder:
             if tag == 'link' and ('dns-prefetch' in attrs.get('rel') or 'preconnect' in attrs.get('rel')):
                 if ':' in value:
                     value = value.split(':', 1)[1]
-                value = 'dns:' + value.strip('/')
+                value = 'dns:' + value.rstrip('/')
             # parse tag for URLs
             self.parse_tag(tag, attr, value, name, base, lineno, column)
         log.debug(LOG_CHECK, "LinkFinder finished tag %s", tag)

--- a/tests/test_linkparser.py
+++ b/tests/test_linkparser.py
@@ -60,6 +60,22 @@ class TestLinkparser(unittest.TestCase):
         url = " alink "
         self._test_one_link(content % url, url)
 
+    def test_rel_parsing(self):
+        # Test <link rel> parsing.
+        content = '<link rel="%s" href="%s">'
+        rel = "dns-prefetch"
+        url = "https://alink"
+        expected = "dns:alink"
+        self._test_one_link(content % (rel, url), expected)
+        url = "//alink/"
+        self._test_one_link(content % (rel, url), expected)
+        rel = "preconnect"
+        url = "https://alink"
+        self._test_one_link(content % (rel, url), expected)
+        rel = "dns-prefetch preconnect"
+        url = "https://alink"
+        self._test_one_link(content % (rel, url), expected)
+
     def test_img_srcset_parsing(self):
         content = '<img srcset="%s 1x">'
         url = "imagesmall.jpg"

--- a/tests/test_linkparser.py
+++ b/tests/test_linkparser.py
@@ -65,7 +65,7 @@ class TestLinkparser(unittest.TestCase):
         content = '<link rel="%s" href="%s">'
         rel = "dns-prefetch"
         url = "https://alink"
-        expected = "dns:alink"
+        expected = "dns://alink"
         self._test_one_link(content % (rel, url), expected)
         url = "//alink/"
         self._test_one_link(content % (rel, url), expected)

--- a/tests/test_linkparser.py
+++ b/tests/test_linkparser.py
@@ -76,6 +76,14 @@ class TestLinkparser(unittest.TestCase):
         url = "https://alink"
         self._test_one_link(content % (rel, url), expected)
 
+    def test_link_without_rel_parsing(self):
+        # <link> tags without rel attr should not raise TypeError.
+        content = '<link href="%s">'
+        url = "https://alink"
+        expected = "https://alink"
+        # Dummy test, we just have to make sure no error was raised.
+        self._test_one_link(content % url, expected)
+
     def test_img_srcset_parsing(self):
         content = '<img srcset="%s 1x">'
         url = "imagesmall.jpg"


### PR DESCRIPTION
I changed a few things in regards to handling link tags, in particular `dns-prefetch` and `preconnect`.

* `rel` attribute can have multiple values, separated by a space, so switched to substring comparison
* `preconnect` usually uses the root URL (eg `https://fonts.googleapis.com`) for setting up a connection, but that URL can return a 404 in some cases, resulting in a false positive. I changed it to a DNS check for now. This could be changed in the future to use a check for a valid http connection.

I added some tests, too :)