### PR TITLE
Ensure chardet is installed when testing using tox

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -195,5 +195,8 @@ class TestParser(unittest.TestCase):
         self.encoding_test(html, "ascii")
 
     def encoding_test(self, html, expected):
+        # If chardet is installed Beautiful Soup uses it for encoding detection.
+        # Results for html without a valid charset may differ
+        # based on chardet availability.
         soup = htmlsoup.make_soup(html)
         self.assertEqual(soup.original_encoding, expected)

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py36, py37, py38, py39
 
 [base]
 deps =
+    chardet
     pyftpdlib
     parameterized
     pdfminer


### PR DESCRIPTION
Beautiful Soup uses chardet, if installed, to detect character
encodings. This can lead to different test results based on whether
chardet is installed or not.

Requests < 2.26.0 requires chardet, but since 2.26.0 Requests requires
charset_normalizer.

Explicitly installing chardet maintains consistent test results.

====

Testing for the first time here. Let's see if it closes #547.
