### PR TITLE
Update documentation with GitHub Actions and prepare for sphinx_rtd_theme 1.0

### DIFF
--- a/doc/src/_templates/layout.html
+++ b/doc/src/_templates/layout.html
@@ -2,8 +2,10 @@
 
   {% block menu %}
     {{ super() }}
-    <a href="{{ pathto('genindex') }}">Index</a>
-    <hr>
-    <a href="https://github.com/linkchecker/linkchecker/blob/master/doc/changelog.txt">Change Log</a>
-    <a href="https://github.com/linkchecker/linkchecker/issues/">Issue Tracker</a>
+  <ul>
+    <li><a href="{{ pathto('genindex') }}">Index</a></li>
+    <li><hr></li>
+    <li><a href="https://github.com/linkchecker/linkchecker/blob/master/doc/changelog.txt">Change Log</a></li>
+    <li><a href="https://github.com/linkchecker/linkchecker/issues/">Issue Tracker</a></li>
+  </ul>
   {% endblock %}

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -75,12 +75,12 @@ Screenshots
 Test suite status
 ------------------
 Linkchecker has extensive unit tests to ensure code quality.
-`Travis CI <https://travis-ci.com/>`_ is used for continuous build
+`GitHub Actions <https://docs.github.com/en/actions/>`_ is used for continuous build
 and test integration.
 
-.. image:: https://travis-ci.com/linkchecker/linkchecker.png
+.. image:: https://github.com/linkchecker/linkchecker/actions/workflows/build.yml/badge.svg?branch=master
    :alt: Build Status
-   :target: https://travis-ci.com/linkchecker/linkchecker
+   :target: https://github.com/linkchecker/linkchecker/actions/workflows/build.yml
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
Reference GitHub Actions instead of Travis in documentation

GitHub Actions refers to itself as singular, at least some of the time.

---

Use an HTML list for custom menu entries in documentation

For compatibility with sphinx_rtd_theme 1.0, which otherwise renders the
entries with buttons.
