### PR TITLE
Improve output documentation and make quiet/-q set log level to warning

### DIFF
--- a/config/linkcheckerrc
+++ b/config/linkcheckerrc
@@ -79,7 +79,7 @@
 # CSV logger
 [csv]
 #filename=linkchecker-out.csv
-#separator=,
+#separator=;
 #quotechar="
 #parts=all
 

--- a/doc/src/man/linkchecker.rst
+++ b/doc/src/man/linkchecker.rst
@@ -162,17 +162,6 @@ Output options
 .. option:: -v, --verbose
 
     Log all checked URLs. Default is to log only errors and warnings.
-    
-.. option:: -W REGEX, --warning-regex=REGEX 
-
-    Define a regular expression which prints a warning if it matches any
-    content of the checked link. This applies only to valid pages, so we
-    can get their content.
-    Use this to check for pages that contain some form of error, for
-    example "This page has moved" or "Oracle Application error".
-    Note that multiple values can be combined in the regular expression,
-    for example "(This page has moved|Oracle Application error)".
-    See section `REGULAR EXPRESSIONS`_ for more info.
 
 Checking options
 ^^^^^^^^^^^^^^^^

--- a/doc/src/man/linkchecker.rst
+++ b/doc/src/man/linkchecker.rst
@@ -156,8 +156,9 @@ Output options
 
 .. option:: -q, --quiet
 
-    Quiet operation, an alias for :option:`-o` *none*. This is only useful with
-    :option:`-F`, else no results will be output.
+    Quiet operation, an alias for :option:`-o` *none* that also hides
+    application information messages.
+    This is only useful with :option:`-F`, else no results will be output.
 
 .. option:: -v, --verbose
 

--- a/doc/src/man/linkchecker.rst
+++ b/doc/src/man/linkchecker.rst
@@ -124,7 +124,7 @@ Output options
 .. option:: -F TYPE[/ENCODING][/FILENAME], --file-output=TYPE[/ENCODING][/FILENAME]
 
     Output to a file linkchecker-out.TYPE,
-    $HOME/.linkchecker/failures for failures output, or
+    $HOME/.linkchecker/failures for the failures output type, or
     FILENAME if specified. The ENCODING specifies the output
     encoding, the default is that of your locale. Valid encodings are
     listed at
@@ -147,10 +147,9 @@ Output options
 
 .. option:: -o TYPE[/ENCODING], --output=TYPE[/ENCODING]
 
-    Specify output type as text, html, sql, csv,
+    Specify the console output type as text, html, sql, csv,
     gml, dot, xml, sitemap, none or failures.
-    Default type is text. The various output types are documented
-    below.
+    Default type is text. The various output types are documented below.
     The ENCODING specifies the output encoding, the default is that of
     your locale. Valid encodings are listed at
     https://docs.python.org/library/codecs.html#standard-encodings.
@@ -158,7 +157,7 @@ Output options
 .. option:: -q, --quiet
 
     Quiet operation, an alias for :option:`-o` *none*. This is only useful with
-    :option:`-F`.
+    :option:`-F`, else no results will be output.
 
 .. option:: -v, --verbose
 

--- a/doc/src/man/linkchecker.rst
+++ b/doc/src/man/linkchecker.rst
@@ -112,14 +112,8 @@ General options
 Output options
 ^^^^^^^^^^^^^^
 
-.. option:: -D STRING, --debug=STRING
-
-    Print debugging output for the given logger. Available loggers are
-    cmdline, checking, cache, dns, plugin and
-    all. Specifying all is an alias for specifying all available
-    loggers. The option can be given multiple times to debug with more
-    than one logger. For accurate results, threading will be disabled
-    during debug runs.
+URL checking results
+""""""""""""""""""""
 
 .. option:: -F TYPE[/ENCODING][/FILENAME], --file-output=TYPE[/ENCODING][/FILENAME]
 
@@ -137,10 +131,6 @@ Output options
     The various output types are documented below. Note that you can
     suppress all console output with the option :option:`-o` *none*.
 
-.. option:: --no-status
-
-    Do not print check status messages.
-
 .. option:: --no-warnings
 
     Don't log warnings. Default is to log warnings.
@@ -154,15 +144,37 @@ Output options
     your locale. Valid encodings are listed at
     https://docs.python.org/library/codecs.html#standard-encodings.
 
+.. option:: -v, --verbose   
+
+    Log all checked URLs. Default is to log only errors and warnings.
+
+Progress updates
+""""""""""""""""
+
+.. option:: --no-status
+
+    Do not print URL check status messages.
+
+Application
+"""""""""""
+
+.. option:: -D STRING, --debug=STRING
+
+    Print debugging output for the given logger. Available loggers are
+    cmdline, checking, cache, dns, plugin and
+    all. Specifying all is an alias for specifying all available
+    loggers. The option can be given multiple times to debug with more
+    than one logger. For accurate results, threading will be disabled
+    during debug runs.
+
+Quiet
+"""""
+
 .. option:: -q, --quiet
 
     Quiet operation, an alias for :option:`-o` *none* that also hides
     application information messages.
     This is only useful with :option:`-F`, else no results will be output.
-
-.. option:: -v, --verbose
-
-    Log all checked URLs. Default is to log only errors and warnings.
 
 Checking options
 ^^^^^^^^^^^^^^^^

--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -184,8 +184,9 @@ output
     https://docs.python.org/library/codecs.html#standard-encodings.
     Command line option: :option:`--output`
 **quiet=**\ [**0**\ \|\ **1**]
-    If set, operate quiet. An alias for **log=none**. This is only
-    useful with **fileoutput**, else no results will be output.
+    If set, operate quiet. An alias for **log=none** that also hides
+    application information messages.
+    This is only useful with **fileoutput**, else no results will be output.
     Command line option: :option:`--quiet`
 **status=**\ [**0**\ \|\ **1**]
     Control printing check status messages. Default is 1.

--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -161,12 +161,9 @@ authentication
 output
 ^^^^^^
 
-**debug=**\ *STRING*\ [**,**\ *STRING*...]
-    Print debugging output for the given modules. Available debug
-    modules are **cmdline**, **checking**, **cache**, **dns**,
-    **thread**, **plugins** and **all**. Specifying **all** is an alias
-    for specifying all available loggers.
-    Command line option: :option:`--debug`
+URL checking results
+""""""""""""""""""""
+
 **fileoutput=**\ *TYPE*\ [**,**\ *TYPE*...]
     Output to a file **linkchecker-out.**\ *TYPE*, or
     **$HOME/.linkchecker/failures** for the **failures** output type.
@@ -183,14 +180,6 @@ output
     your locale. Valid encodings are listed at
     https://docs.python.org/library/codecs.html#standard-encodings.
     Command line option: :option:`--output`
-**quiet=**\ [**0**\ \|\ **1**]
-    If set, operate quiet. An alias for **log=none** that also hides
-    application information messages.
-    This is only useful with **fileoutput**, else no results will be output.
-    Command line option: :option:`--quiet`
-**status=**\ [**0**\ \|\ **1**]
-    Control printing check status messages. Default is 1.
-    Command line option: :option:`--no-status`
 **verbose=**\ [**0**\ \|\ **1**]
     If set log all checked URLs once. Default is to log only errors and
     warnings.
@@ -198,6 +187,35 @@ output
 **warnings=**\ [**0**\ \|\ **1**]
     If set log warnings. Default is to log warnings.
     Command line option: :option:`--no-warnings`
+
+Progress updates
+""""""""""""""""
+
+**status=**\ [**0**\ \|\ **1**]
+    Control printing URL checker status messages. Default is 1.
+    Command line option: :option:`--no-status`
+
+Application
+"""""""""""
+
+**debug=**\ *STRING*\ [**,**\ *STRING*...]
+    Print debugging output for the given modules. Available debug
+    modules are **cmdline**, **checking**, **cache**, **dns**,
+    **thread**, **plugins** and **all**. Specifying **all** is an alias
+    for specifying all available loggers.
+    Command line option: :option:`--debug`
+
+Quiet
+"""""
+
+**quiet=**\ [**0**\ \|\ **1**]
+    If set, operate quiet. An alias for **log=none** that also hides
+    application information messages.
+    This is only useful with **fileoutput**, else no results will be output.
+    Command line option: :option:`--quiet`
+
+OUTPUT TYPES
+------------
 
 text
 ^^^^

--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -274,7 +274,7 @@ csv
 **encoding=**\ *STRING*
     See :ref:`[text] <man/linkcheckerrc:text>` section above.
 **separator=**\ *CHAR*
-    Set CSV separator. Default is a comma (**,**).
+    Set CSV separator. Default is a semicolon (**;**).
 **quotechar=**\ *CHAR*
     Set CSV quote character. Default is a double quote (**"**).
 

--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -231,7 +231,7 @@ text
 **encoding=**\ *STRING*
     Valid encodings are listed in
     https://docs.python.org/library/codecs.html#standard-encodings.
-    Default encoding is **iso-8859-15**.
+    Default encoding is the system default locale encoding.
 *color\**
     Color settings for the various log parts, syntax is *color* or
     *type*\ **;**\ *color*. The *type* can be **bold**, **light**,

--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -169,14 +169,14 @@ output
     Command line option: :option:`--debug`
 **fileoutput=**\ *TYPE*\ [**,**\ *TYPE*...]
     Output to a file **linkchecker-out.**\ *TYPE*, or
-    **$HOME/.linkchecker/failures** for **failures** output.
+    **$HOME/.linkchecker/failures** for the **failures** output type.
     Valid file output types are **text**, **html**, **sql**, **csv**,
     **gml**, **dot**, **xml**, **none** or **failures**. Default is no
     file output. The various output types are documented below. Note
     that you can suppress all console output with **output=none**.
     Command line option: :option:`--file-output`
 **log=**\ *TYPE*\ [**/**\ *ENCODING*]
-    Specify output type as **text**, **html**, **sql**, **csv**,
+    Specify the console output type as **text**, **html**, **sql**, **csv**,
     **gml**, **dot**, **xml**, **none** or **failures**. Default type
     is **text**. The various output types are documented below.
     The *ENCODING* specifies the output encoding, the default is that of
@@ -185,8 +185,8 @@ output
     Command line option: :option:`--output`
 **quiet=**\ [**0**\ \|\ **1**]
     If set, operate quiet. An alias for **log=none**. This is only
-    useful with **fileoutput**.
-    Command line option: :option:`--verbose`
+    useful with **fileoutput**, else no results will be output.
+    Command line option: :option:`--quiet`
 **status=**\ [**0**\ \|\ **1**]
     Control printing check status messages. Default is 1.
     Command line option: :option:`--no-status`

--- a/linkcheck/configuration/confparse.py
+++ b/linkcheck/configuration/confparse.py
@@ -134,6 +134,7 @@ class LCConfigParser(RawConfigParser):
             if self.getboolean(section, "quiet"):
                 self.config['output'] = 'none'
                 self.config['quiet'] = True
+                logconf.reset_loglevel()  # if debug will be overwritten next
         if self.has_option(section, "debug"):
             val = self.get(section, "debug")
             parts = [f.strip().lower() for f in val.split(',')]

--- a/linkchecker
+++ b/linkchecker
@@ -529,6 +529,8 @@ if options.debug:
         if _name not in allowed_debugs:
             print_usage(_("Invalid debug level %(level)r") % {"level": _name})
     logconf.set_debug(options.debug)
+elif options.quiet:
+    logconf.reset_loglevel()
 log.debug(
     LOG_CMDLINE,
     _("Python %(version)s on %(platform)s")


### PR DESCRIPTION
Mainly documentation, but also make quiet/-q silence INFO messages, including "Checking intern URLs only".
