### PR TITLE
Disable AnchorCheck plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Features
 - Cookie support
 - HTML5 support
 - a command line and web interface
-- various check plugins available, eg. HTML syntax and antivirus checks.
+- various check plugins available
 
 Installation
 -------------

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -56,8 +56,7 @@ Features
 - honors robots.txt exclusion protocol
 - Cookie support
 - HTML5 support
-- :ref:`Plugin support <man/linkchecker:PLUGINS>` allowing custom page checks. Currently available are
-  HTML and CSS syntax checks, Antivirus checks, and more.
+- :ref:`Plugin support <man/linkchecker:PLUGINS>` allowing custom page checks
 - Different interfaces: command line and web interface
 
 Screenshots

--- a/doc/src/man/linkchecker.rst
+++ b/doc/src/man/linkchecker.rst
@@ -24,7 +24,6 @@ LinkChecker features
 -  support for robots.txt exclusion protocol
 -  support for Cookies
 -  support for HTML5
--  HTML and CSS syntax check
 -  Antivirus check
 -  a command line and web interface
 

--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -434,6 +434,10 @@ AnchorCheck
 
 Checks validity of HTML anchors.
 
+.. note::
+
+    The AnchorCheck plugin is currently broken and is disabled.
+
 LocationInfo
 ^^^^^^^^^^^^
 
@@ -470,6 +474,10 @@ HtmlSyntaxCheck
 
 Check the syntax of HTML pages with the online W3C HTML validator. See
 https://validator.w3.org/docs/api.html.
+
+.. note::
+
+    The HtmlSyntaxCheck plugin is currently broken and is disabled.
 
 HttpHeaderInfo
 ^^^^^^^^^^^^^^

--- a/linkcheck/plugins/anchorcheck.py
+++ b/linkcheck/plugins/anchorcheck.py
@@ -26,8 +26,16 @@ from ..htmlutil import linkparse
 class AnchorCheck(_ContentPlugin):
     """Checks validity of HTML anchors."""
 
+    def __init__(self, config):
+        """Initialize plugin."""
+        super().__init__(config)
+        log.warn(
+            LOG_PLUGIN, _("Anchor check plugin is broken. Fixes welcome.")
+        )
+
     def applies_to(self, url_data):
         """Check for HTML anchor existence."""
+        return False  # XXX Plugin disabled
         return url_data.is_html() and url_data.anchor
 
     def check(self, url_data):

--- a/tests/checker/test_anchor.py
+++ b/tests/checker/test_anchor.py
@@ -16,6 +16,8 @@
 """
 Test html anchor parsing and checking.
 """
+import pytest
+
 from . import LinkCheckTest
 from .httpserver import HttpServerTest
 
@@ -25,6 +27,7 @@ class TestAnchor(LinkCheckTest):
     Test anchor checking of HTML pages.
     """
 
+    @pytest.mark.xfail(strict=True)
     def test_anchor(self):
         confargs = {"enabledplugins": ["AnchorCheck"]}
         url = "file://%(curdir)s/%(datadir)s/anchor.html" % self.get_attrs()
@@ -46,6 +49,7 @@ class TestHttpAnchor(HttpServerTest):
     Test checking of HTML pages containing links to anchors served over http.
     """
 
+    @pytest.mark.xfail(strict=True)
     def test_anchor_html(self):
         confargs = dict(enabledplugins=["AnchorCheck"], recursionlevel=1)
         self.file_test("http_anchor.html", confargs=confargs)


### PR DESCRIPTION
Can't be relied on. Multiple reports of expected results not returned.

https://github.com/linkchecker/linkchecker/issues/542
https://github.com/linkchecker/linkchecker/issues/555
https://github.com/linkchecker/linkchecker/issues/568

Previously a fix was needed just to get the tests working:
0912e8a2c ("Don't strip the URL fragment from cache key if using AnchorCheck", 2020-07-27)

After:
eaa538c81 ("don't check one url multiple times", 2016-11-09)
