### PR TITLE
Fix LinkChecker version shown on github.io

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -13,6 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        # Needed for setuptools_scm to extract LinkChecker version from tag
+        # https://github.com/actions/checkout/issues/249
+        with:
+          fetch-depth: 0
 
       - name: Install Ubuntu packages
         run: sudo apt install graphviz

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -8,6 +8,8 @@ jobs:
   run:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +33,7 @@ jobs:
             make -C doc html
 
       - name: Publish
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./doc/html


### PR DESCRIPTION
`0.0.post1+g2bc0b71`

(And some security work for the publish Pages action).
