### PR TITLE
Assume robots.txt is UTF-8

### DIFF
--- a/linkcheck/robotparser2.py
+++ b/linkcheck/robotparser2.py
@@ -92,8 +92,9 @@ class RobotFileParser:
         try:
             response = self.session.get(self.url, **kwargs)
             response.raise_for_status()
+            log.debug(LOG_CHECK, "Robots response headers: %s", response.headers)
             content_type = response.headers.get('content-type')
-            self.encoding = response.encoding
+            self.encoding = response.encoding = "utf-8"
             if content_type and content_type.lower().startswith('text/plain'):
                 self.parse(response.iter_lines(decode_unicode=True))
             else:


### PR DESCRIPTION
Match the Python standard library and Google's interpretation:
https://developers.google.com/search/docs/advanced/robots/robots_txt#file-format

Avoid Unhandled LookupError.