### PR TITLE
Remove linkchecker from POSOURCES

### DIFF
--- a/po/Makefile
+++ b/po/Makefile
@@ -2,7 +2,7 @@ XGETTEXT := xgettext
 MSGFMT := msgfmt
 MSGMERGE := msgmerge
 POSOURCES = $(shell find ../linkcheck -name \*.py) \
-	../linkchecker $(shell python3 -c 'import argparse; print(argparse.__file__)')
+	$(shell python3 -c 'import argparse; print(argparse.__file__)')
 PACKAGE = linkchecker
 TEMPLATE = $(PACKAGE).pot
 MYMAIL := bastian.kleineidam@web.de


### PR DESCRIPTION
Removed in:
5fef9a3b ("Generate linkchecker command using an entry point", 2021-12-20)