### PR TITLE
Latest PyOxidizer and Beautiful Soup allow workarounds to be removed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /mnt
 
 # Dependencies change on their own schedule so install them separately
 RUN pip install --no-cache-dir \
-    beautifulsoup4 dnspython pyxdg requests cchardet polib
+    beautifulsoup4 dnspython pyxdg requests polib
 
 RUN set -x \
     && apt-get update -qq \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use the maximum version for which dependency wheels are available
-FROM python:3.9-slim
+# Use the maximum Python version tested
+FROM python:3.10-slim
 
 # linkchecker creates ~/.linkchecker/ (700) containing linkcheckerrc et al
 ENV HOME /tmp

--- a/doc/install.txt
+++ b/doc/install.txt
@@ -15,14 +15,18 @@ There are several steps to resolve problems with detecting the character
 encoding of checked HTML pages:
 first ensure the web server, if used, is not returning an incorrect charset in
 the Content-Type header; second, if possible add a meta element to the HTML
-page with the correct charset; finally, install cchardet_ - Beautiful Soup has
-its own encoding detector but will use in order of preference cchardet_ or
-chardet_. You might find that one of the other three detectors works better for
-your pages. There may already be a system copy of e.g. chardet installed;
+page with the correct charset; finally, check chardet_ is not installed,
+Requests >= 2.26 will install charset-normalizer_, Beautiful Soup has
+its own encoding detector but will use in order of preference cchardet_,
+chardet_ or charset-normalizer_ (Beautiful Soup >= 4.11). You might find that
+one of the other three detectors works better for your pages.
+There may already be a system copy of e.g. chardet installed;
 installing LinkChecker in a Python venv_ gives control over which packages are
 used.
 
 .. _chardet: https://pypi.org/project/chardet/
+
+.. _charset-normalizer: https://pypi.org/project/charset-normalizer/
 
 .. _pip-run: https://pypi.org/project/pip-run/
 

--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,6 @@ else:
 
 # the application name
 AppName = "LinkChecker"
-if "PYOXIDIZER" in os.environ:
-    # Name with capitals not supported by PyOxidizer 0.18.0
-    # https://github.com/indygreg/PyOxidizer/issues/488
-    AppName = AppName.lower()
 Description = "check links in web documents or full websites"
 
 RELEASE_DATE_FILE = "_release_date"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -196,8 +196,8 @@ class TestParser(unittest.TestCase):
 
     def encoding_test(self, html, expected):
         # For encoding detection Beautiful Soup uses if available in order
-        # of preference cchardet then chardet.
+        # of preference cchardet then chardet then charset-normalizer.
         # Results for html without a valid charset may differ
-        # based on cchardet/chardet availability.
+        # based on cchardet/chardet/charset-normalizer availability.
         soup = htmlsoup.make_soup(html)
         self.assertEqual(soup.original_encoding, expected)

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py37, py38, py39, py310
 
 [base]
 deps =
-    cchardet
     pyftpdlib
     parameterized
     pdfminer


### PR DESCRIPTION
Remove cchardet from Docker image, tox env and recommendation

Beautiful Soup 4.11 will use charset-normalizer.

----

Remove PyOxidizer workaround

Not needed with PyOxidizer >= 0.20.0.

---

No runtime changes.

