### PR TITLE
Test and recommend pdfminer.six for PdfParser

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # for testing:
 miniboa
 parameterized
-pdfminer
+pdfminer.six
 pyftpdlib
 pyopenssl
 pytest

--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -525,7 +525,7 @@ daemon must be installed.
 PdfParser
 ^^^^^^^^^
 
-Parse PDF files for URLs to check. Needs the :pypi:`pdfminer` Python package
+Parse PDF files for URLs to check. Needs the :pypi:`pdfminer.six` Python package
 installed.
 
 WordParser

--- a/linkcheck/plugins/parseword.py
+++ b/linkcheck/plugins/parseword.py
@@ -115,7 +115,7 @@ class WordParser(_ParserPlugin):
     """Word parsing plugin."""
 
     def __init__(self, config):
-        """Check for pdfminer."""
+        """Check for Word."""
         init_win32com()
         if not has_word():
             log.warn(LOG_PLUGIN, "Microsoft Word not found for WordParser plugin")

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py37, py38, py39, py310
 deps =
     pyftpdlib
     parameterized
-    pdfminer
+    pdfminer.six
     pyopenssl
     pytest-xdist
     pytest-cov


### PR DESCRIPTION
pdfminer is no longer actively maintained; distributions are now
packaging pdfminer.six as pdfminer.
