### PR TITLE
Document url-rate-limited

### DIFF
--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -574,6 +574,8 @@ file entry:
     Could not get the content of the URL.
 **url-obfuscated-ip**
     The IP is obfuscated.
+**url-rate-limited**
+    Too many HTTP requests.
 **url-whitespace**
     The URL contains leading or trailing whitespace.
 


### PR DESCRIPTION
Introduced in:
dcdc64e8 ("Turn status code 429 into warning instead of failure",
2020-03-25)