### PR TITLE
Fix false positive anchor checks

### DIFF
--- a/linkcheck/plugins/anchorcheck.py
+++ b/linkcheck/plugins/anchorcheck.py
@@ -55,7 +55,7 @@ class AnchorCheck(_ContentPlugin):
         A warning is logged and True is returned if the anchor is not found.
         """
         log.debug(LOG_PLUGIN, "checking anchor %r in %s", url_data.anchor, self.anchors)
-        if any(x for x in self.anchors if urllib.parse.quote(x[0]) == url_data.anchor):
+        if any(x for x in self.anchors if urllib.parse.quote(x[0]) == urllib.parse.quote(url_data.anchor)):
             return
         if self.anchors:
             anchornames = sorted(set("`%s'" % x[0] for x in self.anchors))


### PR DESCRIPTION
The anchor plugin suffers from false positives as documented in [Pull Request 575](https://github.com/linkchecker/linkchecker/pull/575). 

As it seems to me, the reason (or at least one of them) is this piece of code from [`anchorplugin.py`](https://github.com/linkchecker/linkchecker/blob/master/linkcheck/plugins/anchorcheck.py#L58-L59):
```
if any(x for x in self.anchors if urllib.parse.quote(x[0]) == url_data.anchor):
    return
```

Special characters in anchors are not compared correctly here. `urllib.parse.quote` escapes special characters for `x[0]` but they are not escaped for `url_data.anchor`.
Hence, anchors like `THR+13` (no escape) was compared to `THR%2B13` (with escape) resulting in `False` (and thus a false positive) as result. 

This PR changes this code to:
```
if any(x for x in self.anchors if urllib.parse.quote(x[0]) == urllib.parse.quote(url_data.anchor)):
    return
```