### PR TITLE
Remove dependency on pyxdg

### DIFF
--- a/.github/workflows/branch-man.yml
+++ b/.github/workflows/branch-man.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install Python packages
         run: >
-            pip3 install dnspython beautifulsoup4 pyxdg requests \
+            pip3 install dnspython beautifulsoup4 requests \
                          sphinx sphinx_epytext sphinx_rtd_theme sphinx-sitemap \
                          sphinx-intl setuptools_scm
 

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install Python packages
         run: >
-            pip install dnspython beautifulsoup4 pyxdg requests \
+            pip install dnspython beautifulsoup4 requests \
                         sphinx sphinx_epytext sphinx_rtd_theme sphinx-sitemap
 
       - name: Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ VOLUME /mnt
 WORKDIR /mnt
 
 # Dependencies change on their own schedule so install them separately
-RUN pip install --no-cache-dir \
-    beautifulsoup4 dnspython pyxdg requests polib
+RUN pip install --no-cache-dir beautifulsoup4 dnspython requests polib
 
 RUN set -x \
     && apt-get update -qq \

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -1,3 +1,9 @@
+10.x
+
+Changes:
+- PyXDG is no longer used
+
+
 10.1.0 (released 22.12.2021)
 
 Features:

--- a/linkcheck/configuration/__init__.py
+++ b/linkcheck/configuration/__init__.py
@@ -33,7 +33,6 @@ except ImportError:
 
 from .. import log, LOG_CHECK, COMMAND_NAME, PACKAGE_NAME, fileutil
 from . import confparse
-from xdg.BaseDirectory import xdg_config_home, xdg_data_home
 
 linkchecker_distribution = distribution(COMMAND_NAME)
 Version = linkchecker_distribution.metadata["Version"]
@@ -74,7 +73,6 @@ Modules = (
     ("bs4", "Beautiful Soup", "__version__"),
     ("dns.version", "dnspython", "version"),
     ("requests", "Requests", "__version__"),
-    ("xdg", "PyXDG", "__version__"),
     # optional modules
     ("argcomplete", "Argcomplete", None),
     ("GeoIP", "GeoIP", 'lib_version'),  # on Unix systems
@@ -332,7 +330,10 @@ def get_user_data():
     userdata = (
         homedotdir
         if os.path.isdir(homedotdir)
-        else os.path.join(xdg_data_home, "linkchecker")
+        else os.path.join(
+            os.environ.get("XDG_DATA_HOME") or os.path.expanduser(
+                os.path.join("~", ".local", "share")),
+            "linkchecker")
     )
     return userdata
 
@@ -381,7 +382,10 @@ def get_user_config():
     userconf = (
         homedotfile
         if os.path.isfile(homedotfile)
-        else os.path.join(xdg_config_home, "linkchecker", "linkcheckerrc")
+        else os.path.join(
+            os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser(
+                os.path.join("~", ".config")),
+            "linkchecker", "linkcheckerrc")
     )
     if not os.path.exists(userconf):
         # initial config (with all options explained)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # required:
 beautifulsoup4 >= 4.8.1
 requests >= 2.4
-pyxdg
 dnspython >= 2.0
 # optional:
 argcomplete

--- a/setup.py
+++ b/setup.py
@@ -225,7 +225,6 @@ setup(
         "requests >= 2.4",
         "dnspython >= 2.0",
         "beautifulsoup4 >= 4.8.1",
-        "pyxdg",
     ],
     # Commented out since they are untested and not officially supported.
     # See also doc/install.txt for more detailed dependency documentation.


### PR DESCRIPTION
Read the environment variables and implement the same fallbacks.
Saves a hardly used dependency and is more explicit.