### PR TITLE
Rename url-rate-limited to http-rate-limited

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -7,6 +7,7 @@ Changes:
 - Documentation build is run using hatch
 - Binary translation catalogs are compiled using polib during distribution
   package building and are now included in sdist packages
+- Warning url-rate-limited renamed to http-rate-limited.
 
 
 10.1.0 (released 22.12.2021)

--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -559,6 +559,8 @@ file entry:
     An error occurred while storing a cookie.
 **http-empty-content**
     The URL had no content.
+**http-rate-limited**
+    Too many HTTP requests.
 **mail-no-mx-host**
     The mail MX host could not be found.
 **nntp-no-newsgroup**
@@ -577,8 +579,6 @@ file entry:
     Could not get the content of the URL.
 **url-obfuscated-ip**
     The IP is obfuscated.
-**url-rate-limited**
-    Too many HTTP requests.
 **url-whitespace**
     The URL contains leading or trailing whitespace.
 

--- a/doc/upgrading.txt
+++ b/doc/upgrading.txt
@@ -8,6 +8,8 @@ Compiled application translations are now also included in the sdist package.
 No need to install polib before installing any distribution package. It is
 still required for building distribution packages that include translations.
 
+Warning url-rate-limited renamed to http-rate-limited.
+
 Migrating from 10.0 to 10.1
 ---------------------------
 If installing from source and application translations are needed the Python

--- a/linkcheck/checker/const.py
+++ b/linkcheck/checker/const.py
@@ -87,7 +87,6 @@ WARN_URL_CONTENT_SIZE_TOO_LARGE = "url-content-too-large"
 WARN_URL_CONTENT_SIZE_ZERO = "url-content-size-zero"
 WARN_URL_CONTENT_TYPE_UNPARSEABLE = "url-content-type-unparseable"
 WARN_URL_OBFUSCATED_IP = "url-obfuscated-ip"
-WARN_URL_RATE_LIMITED = "url-rate-limited"
 WARN_URL_TOO_LONG = "url-too-long"
 WARN_URL_WHITESPACE = "url-whitespace"
 WARN_FILE_MISSING_SLASH = "file-missing-slash"
@@ -95,6 +94,7 @@ WARN_FILE_SYSTEM_PATH = "file-system-path"
 WARN_FTP_MISSING_SLASH = "ftp-missing-slash"
 WARN_HTTP_EMPTY_CONTENT = "http-empty-content"
 WARN_HTTP_COOKIE_STORE_ERROR = "http-cookie-store-error"
+WARN_HTTP_RATE_LIMITED = "http-rate-limited"
 WARN_IGNORE_URL = "ignore-url"
 WARN_MAIL_NO_MX_HOST = "mail-no-mx-host"
 WARN_NNTP_NO_SERVER = "nntp-no-server"
@@ -108,9 +108,6 @@ Warnings = {
     WARN_URL_CONTENT_SIZE_TOO_LARGE: _("The URL content size is too large."),
     WARN_URL_CONTENT_SIZE_ZERO: _("The URL content size is zero."),
     WARN_URL_CONTENT_TYPE_UNPARSEABLE: _("The URL content type is not parseable."),
-    WARN_URL_RATE_LIMITED: _(
-        "The URL request was rate limited so need reduce number of requests."
-    ),
     WARN_URL_TOO_LONG: _("The URL is longer than the recommended size."),
     WARN_URL_WHITESPACE: _("The URL contains leading or trailing whitespace."),
     WARN_FILE_MISSING_SLASH: _("The file: URL is missing a trailing slash."),
@@ -120,6 +117,7 @@ Warnings = {
     WARN_FTP_MISSING_SLASH: _("The ftp: URL is missing a trailing slash."),
     WARN_HTTP_EMPTY_CONTENT: _("The URL had no content."),
     WARN_HTTP_COOKIE_STORE_ERROR: _("An error occurred while storing a cookie."),
+    WARN_HTTP_RATE_LIMITED: _("The URL request was rate limited."),
     WARN_IGNORE_URL: _("The URL has been ignored."),
     WARN_MAIL_NO_MX_HOST: _("The mail MX host could not be found."),
     WARN_NNTP_NO_SERVER: _("No NNTP server was found."),

--- a/linkcheck/checker/httpurl.py
+++ b/linkcheck/checker/httpurl.py
@@ -43,7 +43,7 @@ from .. import (
 from . import internpaturl
 
 # import warnings
-from .const import WARN_HTTP_EMPTY_CONTENT, WARN_URL_RATE_LIMITED
+from .const import WARN_HTTP_EMPTY_CONTENT, WARN_HTTP_RATE_LIMITED
 from requests.sessions import REDIRECT_STATI
 
 HTTP_SCHEMAS = ('http://', 'https://')
@@ -315,7 +315,7 @@ class HttpUrl(internpaturl.InternPatternUrl):
                 self.add_warning(
                     "Rate limited (Retry-After: %s)"
                     % self.headers.get("Retry-After"),
-                    tag=WARN_URL_RATE_LIMITED,
+                    tag=WARN_HTTP_RATE_LIMITED,
                 )
 
             if self.url_connection.status_code >= 200:


### PR DESCRIPTION
Make consistent with the other warnings:

- The first part of the name represents the checker class in which the
  warning is raised

- Update initial comment