### PR TITLE
Fix formatting of ignoreerrors example in linkcheckerrc(5)

### DIFF
--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -195,15 +195,13 @@ URL checking results
     second expression is omitted, all errors are ignored. In contrast
     to filtering_, this happens *after* checking, which allows checking
     URLs despite certain expected and tolerable errors. Default is to
-    not ignore any errors.
+    not ignore any errors. Example:
 
-    ::
+::
+
     [output]
-
     ignoreerrors=
-
       ^https://deprecated\.example\.com ^410 Gone
-
       # ignore all errors (no second expression), also for syntax check:
       ^mailto:.*@example\.com$
 


### PR DESCRIPTION
Introduced in:
8c959589 ("add option to ignore specific errors for specific URLs", 2022-07-21)

---

![image](https://user-images.githubusercontent.com/921089/192859739-8a5917a6-6ef4-4b81-a7b2-10c2aa853a47.png)

I included an Example and removed the spacing (at a premium?).
