### PR TITLE
Fix tests failing when run with pytest

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,10 +18,23 @@ import subprocess
 import os
 import sys
 import socket
+import unittest
 import pytest
 from contextlib import contextmanager
 from functools import lru_cache, wraps
-from linkcheck import LinkCheckerInterrupt
+from linkcheck import init_i18n, LinkCheckerInterrupt
+
+
+class TestBase(unittest.TestCase):
+    """
+    Base class for tests.
+    """
+
+    def setUp(self):
+        """Ensure the current locale setting is the default.
+        Otherwise, warnings will get translated and will break tests."""
+        super().setUp()
+        init_i18n(loc="C")
 
 
 def run(cmd, verbosity=0, **kwargs):

--- a/tests/checker/__init__.py
+++ b/tests/checker/__init__.py
@@ -19,12 +19,11 @@ Define standard test support classes functional for LinkChecker tests.
 import os
 import re
 import difflib
-import unittest
 import linkcheck.checker
 import linkcheck.configuration
 import linkcheck.director
 import linkcheck.logger
-from .. import get_file
+from .. import get_file, TestBase
 
 # helper alias
 get_url_from = linkcheck.checker.get_url_from
@@ -190,18 +189,12 @@ def get_test_aggregate(confargs, logargs, logger=TestLogger):
     return linkcheck.director.get_aggregate(config)
 
 
-class LinkCheckTest(unittest.TestCase):
+class LinkCheckTest(TestBase):
     """
     Functional test class with ability to test local files.
     """
 
     logger = TestLogger
-
-    def setUp(self):
-        """Ensure the current locale setting is the default.
-        Otherwise, warnings will get translated and will break tests."""
-        super().setUp()
-        linkcheck.init_i18n(loc="C")
 
     def norm(self, url, encoding="utf-8"):
         """Helper function to norm a url."""

--- a/tests/checker/ftpserver.py
+++ b/tests/checker/ftpserver.py
@@ -38,6 +38,7 @@ class FtpServerTest(LinkCheckTest):
 
     def setUp(self):
         """Start a new FTP server in a new thread."""
+        super().setUp()
         self.port = start_server(self.host, 0)
         self.assertFalse(self.port is None)
 

--- a/tests/checker/telnetserver.py
+++ b/tests/checker/telnetserver.py
@@ -49,6 +49,7 @@ class TelnetServerTest(LinkCheckTest):
 
     def setUp(self):
         """Start a new Telnet server in a new thread."""
+        super().setUp()
         self.port, self.server_thread = start_server(self.host, 0, self.stop_event)
         self.assertFalse(self.port is None)
 

--- a/tests/checker/test_build_url.py
+++ b/tests/checker/test_build_url.py
@@ -16,15 +16,14 @@
 """
 Test UrlBase.build_url()
 """
-import unittest
-
 import linkcheck.configuration
 import linkcheck.director
 
 from . import get_url_from
+from .. import TestBase
 
 
-class TestBuildUrl(unittest.TestCase):
+class TestBuildUrl(TestBase):
     """Test parsing of URLs by UrlBase.build_url()."""
 
     def test_build_url(self):

--- a/tests/configuration/test_config.py
+++ b/tests/configuration/test_config.py
@@ -17,10 +17,11 @@
 Test config parsing.
 """
 
-import unittest
 import os
 from re import Pattern
 import linkcheck.configuration
+
+from .. import TestBase
 
 
 def get_file(filename=None):
@@ -31,7 +32,7 @@ def get_file(filename=None):
     return directory
 
 
-class TestConfig(unittest.TestCase):
+class TestConfig(TestBase):
     """Test configuration parsing."""
 
     def test_confparse(self):

--- a/tests/logger/test_csvlog.py
+++ b/tests/logger/test_csvlog.py
@@ -14,12 +14,13 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import unittest
 import os
 from linkcheck.logger.csvlog import CSVLogger
 
+from .. import TestBase
 
-class TestCsvLogger(unittest.TestCase):
+
+class TestCsvLogger(TestBase):
     def test_parts(self):
         args = dict(
             filename=os.path.join(os.path.dirname(__file__), "testlog.csv"),

--- a/tests/test_cgi.py
+++ b/tests/test_cgi.py
@@ -16,15 +16,16 @@
 """
 Test cgi form routines.
 """
-import unittest
 import urllib.parse
 from io import BytesIO
 from wsgiref.util import setup_testing_defaults
 from linkcheck.lc_cgi import checkform, checklink, LCFormError, application
 from linkcheck.strformat import limit
 
+from . import TestBase
 
-class TestWsgi(unittest.TestCase):
+
+class TestWsgi(TestBase):
     """Test wsgi application."""
 
     def test_form_valid_url(self):

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -17,11 +17,12 @@
 Test console operations.
 """
 
-import unittest
 import linkcheck.director.console
 
+from . import TestBase
 
-class TestConsole(unittest.TestCase):
+
+class TestConsole(TestBase):
     """Test console operations."""
 
     def test_internal_error(self):

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -18,14 +18,15 @@ Test cookie routines.
 """
 
 import os
-import unittest
 
 import linkcheck.cookies
 import linkcheck.configuration
 import linkcheck.director
 
+from . import TestBase
 
-class TestCookies(unittest.TestCase):
+
+class TestCookies(TestBase):
     """Test cookie routines."""
 
     def test_cookie_parse_multiple_headers(self):

--- a/tests/test_linkparser.py
+++ b/tests/test_linkparser.py
@@ -17,11 +17,12 @@
 Test linkparser routines.
 """
 
-import unittest
 from linkcheck.htmlutil import htmlsoup, linkparse
 
+from . import TestBase
 
-class TestLinkparser(unittest.TestCase):
+
+class TestLinkparser(TestBase):
     """
     Test link parsing.
     """


### PR DESCRIPTION
TypeError: 'NoneType' object is not callable

As per:
2cbff492 ("Fix http tests failing with pytest due to missing _()", 2022-10-03)