### PR TITLE
Add a feature to report all references to a URL [cherry-pick]

### DIFF
--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -185,6 +185,9 @@ URL checking results
     your locale. Valid encodings are listed at
     https://docs.python.org/library/codecs.html#standard-encodings.
     Command line option: :option:`--output`
+**reportallreferences=**\ [**0**\ \|\ **1**]
+    Report all references to a URL, not just the first one.
+    Command line option: :option:`--allrefs`
 **verbose=**\ [**0**\ \|\ **1**]
     If set log all checked URLs once. Default is to log only errors and
     warnings.

--- a/linkcheck/command/arg_parser.py
+++ b/linkcheck/command/arg_parser.py
@@ -302,6 +302,12 @@ class ArgParser(LCArgumentParser):
             help=_("Don't log warnings. Default is to log warnings."),
         )
         group.add_argument(
+            "--allrefs",
+            action="store_true",
+            dest="reportallreferences",
+            help=_("Report all references to a URL, not just the first one."),
+        )
+        group.add_argument(
             "-o",
             "--output",
             dest="output",

--- a/linkcheck/command/setup_config.py
+++ b/linkcheck/command/setup_config.py
@@ -54,6 +54,8 @@ def setup_config(config, options):
         print_version()
     if not options.warnings:
         config["warnings"] = options.warnings
+    if options.reportallreferences:
+        config["reportallreferences"] = True
     if options.externstrict:
         pats = [get_link_pat(arg, strict=True) for arg in options.externstrict]
         config["externlinks"].extend(pats)

--- a/linkcheck/configuration/__init__.py
+++ b/linkcheck/configuration/__init__.py
@@ -177,6 +177,7 @@ class Configuration(dict):
         self['quiet'] = False
         self["verbose"] = False
         self["warnings"] = True
+        self["reportallreferences"] = False
         self["fileoutput"] = []
         self['output'] = 'text'
         self["status"] = True

--- a/linkcheck/configuration/confparse.py
+++ b/linkcheck/configuration/confparse.py
@@ -158,6 +158,7 @@ class LCConfigParser(RawConfigParser):
             val = self.get(section, "debug")
             parts = [f.strip().lower() for f in val.split(',')]
             logconf.set_debug(parts)
+        self.read_boolean_option(section, "reportallreferences")
         self.read_boolean_option(section, "status")
         if self.has_option(section, "log"):
             val = self.get(section, "log").strip().lower()

--- a/linkcheck/data/linkcheckerrc
+++ b/linkcheck/data/linkcheckerrc
@@ -14,6 +14,8 @@
 #verbose=0
 # turn on/off --warnings
 #warnings=1
+# turn on/off --allrefs
+#reportallreferences=0
 # turn on/off --quiet
 #quiet=0
 # additional file output, example:

--- a/linkcheck/director/checker.py
+++ b/linkcheck/director/checker.py
@@ -42,7 +42,7 @@ def check_url(url_data, logger):
         logger.log_url(url_data.to_wire())
     else:
         cache = url_data.aggregate.result_cache
-        key = url_data.cache_url
+        key = url_data.result_cache_url
         result = cache.get_result(key)
         if result is None:
             # check

--- a/tests/checker/data/allrefs1.html
+++ b/tests/checker/data/allrefs1.html
@@ -1,0 +1,20 @@
+
+<!-- targets -->
+<a name="oneone">one one</a>
+
+<!-- links -->
+<a href="allrefs1.html">allrefs1 first</a>
+<a href="allrefs1.html">allrefs1 second</a>
+
+<a href="allrefs1.html#oneone">allrefs1 oneone first</a>
+<a href="#oneone">allrefs1 oneone second</a>
+
+<a href="allrefs1.html#onebroken">allrefs1 onebroken first</a>
+<a href="allrefs1.html#onebroken">allrefs1 onebroken second</a>
+<a href="#onebroken">allrefs1 onebroken third</a>
+
+<a href="allrefs2.html">allrefs2 first</a>
+
+<a href="allrefs2.html#twoone">allrefs2 twoone first</a>
+
+<a href="allrefs2.html#twobroken">allrefs2 twobroken first</a>

--- a/tests/checker/data/allrefs1.html.allrefs.result
+++ b/tests/checker/data/allrefs1.html.allrefs.result
@@ -1,0 +1,126 @@
+
+url #onebroken
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs1.html#onebroken; line: 12
+real url file://%(curdir)s/%(datadir)s/allrefs1.html#onebroken
+name allrefs1 onebroken third
+warning Anchor `onebroken' (decoded: `onebroken') not found. Available anchors: `oneone'.
+valid
+
+url #oneone
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs1.html#oneone; line: 9
+real url file://%(curdir)s/%(datadir)s/allrefs1.html#oneone
+name allrefs1 oneone second
+valid
+
+url #twobroken
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs2.html#twobroken; line: 20
+real url file://%(curdir)s/%(datadir)s/allrefs2.html#twobroken
+name allrefs2 twobroken third
+warning Anchor `twobroken' (decoded: `twobroken') not found. Available anchors: `twoone'.
+valid
+
+url #twoone
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs2.html#twoone; line: 18
+real url file://%(curdir)s/%(datadir)s/allrefs2.html#twoone
+name allrefs2 twoone third
+valid
+
+url allrefs1.html
+cache key file://%(curdir)s/%(datadir)s/allrefs1.html
+real url file://%(curdir)s/%(datadir)s/allrefs1.html
+name allrefs1 first
+valid
+
+url allrefs1.html
+cache key file://%(curdir)s/%(datadir)s/allrefs1.html
+real url file://%(curdir)s/%(datadir)s/allrefs1.html
+name allrefs1 second
+valid
+
+url allrefs1.html#onebroken
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs1.html#onebroken; line: 12
+real url file://%(curdir)s/%(datadir)s/allrefs1.html#onebroken
+name allrefs1 onebroken Nth
+warning Anchor `onebroken' (decoded: `onebroken') not found. Available anchors: `oneone'.
+valid
+
+url allrefs1.html#onebroken
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs1.html#onebroken; line: 12
+real url file://%(curdir)s/%(datadir)s/allrefs1.html#onebroken
+name allrefs1 onebroken first
+warning Anchor `onebroken' (decoded: `onebroken') not found. Available anchors: `oneone'.
+valid
+
+url allrefs1.html#onebroken
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs1.html#onebroken; line: 12
+real url file://%(curdir)s/%(datadir)s/allrefs1.html#onebroken
+name allrefs1 onebroken second
+warning Anchor `onebroken' (decoded: `onebroken') not found. Available anchors: `oneone'.
+valid
+
+url allrefs1.html#oneone
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs1.html#oneone; line: 9
+real url file://%(curdir)s/%(datadir)s/allrefs1.html#oneone
+name allrefs1 oneone Nth
+valid
+
+url allrefs1.html#oneone
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs1.html#oneone; line: 9
+real url file://%(curdir)s/%(datadir)s/allrefs1.html#oneone
+name allrefs1 oneone first
+valid
+
+url allrefs2.html
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs2.html; line: 16
+real url file://%(curdir)s/%(datadir)s/allrefs2.html
+name allrefs2 first
+valid
+
+url allrefs2.html
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs2.html; line: 16
+real url file://%(curdir)s/%(datadir)s/allrefs2.html
+name allrefs2 second (first was from allrefs1)
+valid
+
+url allrefs2.html
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs2.html; line: 16
+real url file://%(curdir)s/%(datadir)s/allrefs2.html
+name allrefs2 third
+valid
+
+url allrefs2.html#twobroken
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs2.html#twobroken; line: 20
+real url file://%(curdir)s/%(datadir)s/allrefs2.html#twobroken
+name allrefs2 twobroken first
+warning Anchor `twobroken' (decoded: `twobroken') not found. Available anchors: `twoone'.
+valid
+
+url allrefs2.html#twobroken
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs2.html#twobroken; line: 20
+real url file://%(curdir)s/%(datadir)s/allrefs2.html#twobroken
+name allrefs2 twobroken second (first was from allrefs1)
+warning Anchor `twobroken' (decoded: `twobroken') not found. Available anchors: `twoone'.
+valid
+
+url allrefs2.html#twoone
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs2.html#twoone; line: 18
+real url file://%(curdir)s/%(datadir)s/allrefs2.html#twoone
+name allrefs2 twoone first
+valid
+
+url allrefs2.html#twoone
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs1.html; target: file://%(curdir)s/%(datadir)s/allrefs2.html#twoone; line: 18
+real url file://%(curdir)s/%(datadir)s/allrefs2.html#twoone
+name allrefs2 twoone second (first was from allrefs1)
+valid
+
+url allrefs3.html
+cache key parent: file://%(curdir)s/%(datadir)s/allrefs2.html; target: file://%(curdir)s/%(datadir)s/allrefs3.html; line: 15
+real url file://%(curdir)s/%(datadir)s/allrefs3.html
+name allrefs3 only
+valid
+
+url file://%(curdir)s/%(datadir)s/allrefs1.html
+cache key file://%(curdir)s/%(datadir)s/allrefs1.html
+real url file://%(curdir)s/%(datadir)s/allrefs1.html
+valid

--- a/tests/checker/data/allrefs1.html.result
+++ b/tests/checker/data/allrefs1.html.result
@@ -1,0 +1,43 @@
+url allrefs1.html#onebroken
+cache key file://%(curdir)s/%(datadir)s/allrefs1.html#onebroken
+real url file://%(curdir)s/%(datadir)s/allrefs1.html#onebroken
+name allrefs1 onebroken first
+warning Anchor `onebroken' (decoded: `onebroken') not found. Available anchors: `oneone'.
+valid
+
+url allrefs1.html#oneone
+cache key file://%(curdir)s/%(datadir)s/allrefs1.html#oneone
+real url file://%(curdir)s/%(datadir)s/allrefs1.html#oneone
+name allrefs1 oneone first
+valid
+
+url allrefs2.html
+cache key file://%(curdir)s/%(datadir)s/allrefs2.html
+real url file://%(curdir)s/%(datadir)s/allrefs2.html
+name allrefs2 first
+valid
+
+url allrefs2.html#twobroken
+cache key file://%(curdir)s/%(datadir)s/allrefs2.html#twobroken
+real url file://%(curdir)s/%(datadir)s/allrefs2.html#twobroken
+name allrefs2 twobroken first
+warning Anchor `twobroken' (decoded: `twobroken') not found. Available anchors: `twoone'.
+valid
+
+url allrefs2.html#twoone
+cache key file://%(curdir)s/%(datadir)s/allrefs2.html#twoone
+real url file://%(curdir)s/%(datadir)s/allrefs2.html#twoone
+name allrefs2 twoone first
+valid
+
+url allrefs3.html
+cache key file://%(curdir)s/%(datadir)s/allrefs3.html
+real url file://%(curdir)s/%(datadir)s/allrefs3.html
+name allrefs3 only
+valid
+
+url file://%(curdir)s/%(datadir)s/allrefs1.html
+cache key file://%(curdir)s/%(datadir)s/allrefs1.html
+real url file://%(curdir)s/%(datadir)s/allrefs1.html
+valid
+

--- a/tests/checker/data/allrefs2.html
+++ b/tests/checker/data/allrefs2.html
@@ -1,0 +1,17 @@
+
+<!-- targets -->
+<a name="twoone">two one</a>
+
+<-- links -->
+<a href="allrefs2.html">allrefs2 second (first was from allrefs1)</a>
+<a href="allrefs2.html">allrefs2 third</a>
+
+<a href="allrefs2.html#twoone">allrefs2 twoone second (first was from allrefs1)</a>
+<a href="#twoone">allrefs2 twoone third</a>
+
+<a href="allrefs2.html#twobroken">allrefs2 twobroken second (first was from allrefs1)</a>
+<a href="#twobroken">allrefs2 twobroken third</a>
+
+<a href="allrefs3.html">allrefs3 only</a>
+
+

--- a/tests/checker/data/allrefs3.html
+++ b/tests/checker/data/allrefs3.html
@@ -1,0 +1,9 @@
+
+<!-- targets -->
+<a name="threeone">three one</a>
+
+<-- links -->
+<a href="allrefs1.html#oneone">allrefs1 oneone Nth</a>
+
+<a href="allrefs1.html#onebroken">allrefs1 onebroken Nth</a>
+

--- a/tests/checker/test_reportallreferences.py
+++ b/tests/checker/test_reportallreferences.py
@@ -1,0 +1,80 @@
+"""
+Test the reportallreferences setting
+"""
+
+from unittest.mock import patch
+from linkcheck.htmlutil import linkparse
+
+from . import LinkCheckTest
+
+
+class TestAllRefs(LinkCheckTest):
+    """ Test the reportallreferences setting """
+
+    def test_without_allrefs(self):
+        """ Test with reportallreferences off (the default) """
+
+        filename = "allrefs1.html"
+        confargs = {"enabledplugins": ["AnchorCheck"]}
+        url = f"file://%(curdir)s/%(datadir)s/{filename}" % self.get_attrs()
+        resultlines = self.get_resultlines(f"{filename}")
+
+        self.direct(url, resultlines, recursionlevel=4, confargs=confargs)
+
+    def test_with_allrefs(self):
+        """ Test with reportallreferences on """
+
+        filename = "allrefs1.html"
+        confargs = {"reportallreferences": 1, "enabledplugins": ["AnchorCheck"]}
+        url = f"file://%(curdir)s/%(datadir)s/{filename}" % self.get_attrs()
+        resultlines = self.get_resultlines(f"{filename}.allrefs")
+
+        self.direct(url, resultlines, recursionlevel=4, confargs=confargs)
+
+    def test_caching_with_allrefs(self):
+        """
+        Check that we aren't doing a bunch of unnecessary work,
+        with reportallreferences on.
+        """
+
+        # setup the test data
+        filename = "allrefs1.html"
+        confargs = {"enabledplugins": ["AnchorCheck"]}
+        url = f"file://%(curdir)s/%(datadir)s/{filename}" % self.get_attrs()
+
+        # make a mock for linkparse.find_links that calls the original function,
+        # so we can track call counts
+        original_find_links = linkparse.find_links
+        with patch(
+                "linkcheck.htmlutil.linkparse.find_links",
+                autospec=True,
+                side_effect=original_find_links) as proxy_find_links:
+
+            # test with reportallreferences off
+            confargs["reportallreferences"] = 0
+            resultlines = self.get_resultlines(f"{filename}")
+            self.direct(url, resultlines, recursionlevel=4, confargs=confargs)
+
+            # 3 for the HTML files,
+            # plus 2 for the two that have references with anchors,
+            # because of AnchorCheck
+            expected = 5
+            actual = proxy_find_links.call_count
+            if actual != expected:
+                self.fail(f"expected {expected} find_links calls"
+                          + f" with reportallreferences disabled, but got {actual}")
+
+            # reset the mock
+            proxy_find_links.call_count = 0
+
+            # test with reportallreferences on
+            confargs["reportallreferences"] = 1
+            resultlines = self.get_resultlines(f"{filename}.allrefs")
+            self.direct(url, resultlines, recursionlevel=4, confargs=confargs)
+
+            # expected doesn't change, if we're doing it right!
+            # expected = <same>
+            actual = proxy_find_links.call_count
+            if actual != expected:
+                self.fail(f"expected {expected} find_links calls"
+                          + f"with reportallreferences enabled, but got {actual}")


### PR DESCRIPTION
This is 2a9ec3fe6f808cb4104359a0ddc24ddc896ea912 from  #663 cherry-picked with the following resolved:

```diff
--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@@ -397,9 -384,14 +399,18 @@@ class UrlBase
              self.info.append(s)
  
      def set_cache_url(self):
-         """Set the URL to be used for caching."""
+         """Set the URLs to be used for caching."""
+ 
          if "AnchorCheck" in self.aggregate.config["enabledplugins"]:
++<<<<<<< HEAD
 +            self.cache_url = self.url
++=======
+             log.debug(
+                 LOG_CHECK,
+                 "set_cache_url: self.url: %s; self.anchor: %s; self.urlparts[4]: %s",
+                 self.url, self.anchor, self.urlparts[4])
+             self.result_cache_url = self.url
++>>>>>>> 2a9ec3fe (Add a feature to report all references to a URL)
          else:
              # remove anchor from cached target url since we assume
              # URLs with different anchors to have the same content
diff --cc linkcheck/data/linkcheckerrc
index cd1d0765,95013c74..00000000
--- a/linkcheck/data/linkcheckerrc
+++ b/linkcheck/data/linkcheckerrc
@@@ -9,21 -9,17 +9,27 @@@
  # print status output
  #status=1
  # change the logging type
 -#log=xml
 +#log=text
  # turn on/off --verbose
 -#verbose=1
 +#verbose=0
  # turn on/off --warnings
++<<<<<<< HEAD
 +#warnings=1
++=======
+ #warnings=0
+ # turn on/off --allrefs
+ #reportallreferences=1
++>>>>>>> 2a9ec3fe (Add a feature to report all references to a URL)
  # turn on/off --quiet
 -#quiet=1
 -# additional file output
 +#quiet=0
 +# additional file output, example:
  #fileoutput = text, html, gml, sql
 +# errors to ignore (URL regular expression, message regular expression)
 +#ignoreerrors=
 +# ignore all errors for broken.example.com:
 +#  ^https?://broken.example.com/
 +# ignore SSL errors for dev.example.com:
 +#  ^https://dev.example.com/ ^SSLError .*
  
  
  ##################### logger configuration ##########################
```
