### PR TITLE
Specify source encoding to xgettext

### DIFF
--- a/po/Makefile
+++ b/po/Makefile
@@ -19,6 +19,7 @@ $(TEMPLATE): $(POSOURCES)
 	$(XGETTEXT) -w 80 --default-domain=$(PACKAGE) --language=Python \
 	  --copyright-holder="Bastian Kleineidam <$(MYMAIL)>" \
 	  --package-name=LinkChecker \
+	  --from-code=UTF-8 \
 	  --msgid-bugs-address=$(BUGSURL) -o $(TEMPLATE) \
 	  --keyword=_n:1,2 $(POSOURCES)
 


### PR DESCRIPTION
Default is ASCII.

xgettext: Non-ASCII string at ../linkcheck/htmlutil/srcsetparse.py:39.
          Please specify the source encoding through --from-code or through a comment
          as specified in http://www.python.org/peps/pep-0263.html.