### PR TITLE
Cache ClamAV signatures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,18 @@ jobs:
     steps:
       - name: Install OS dependencies
         run: |
-          sudo apt update
-          sudo apt install -y clamav-daemon geoip-database libgeoip-dev gettext
+          sudo apt-get update
+          sudo apt-get install -y clamav-daemon geoip-database libgeoip-dev gettext
+
+      - name: ClamAV cache
+        id: cache-clamav
+        uses: actions/cache@v3
+        with:
+          path: /var/lib/clamav
+          key: clamav-v1
 
       - name: Download the ClamAV signature database
+        if: ${{ steps.cache-clamav.outputs.cache-hit != 'true' }}
         run: |
           sudo service clamav-freshclam stop
           sudo freshclam
@@ -92,7 +100,7 @@ jobs:
 
       - name: Install Ubuntu packages
         run: |
-          sudo apt install -y graphviz mandoc
+          sudo apt-get install -y graphviz mandoc
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
We don't care if the signatures are stale (we only need the EICAR virus test signature), so run freshclam only if the cache is missing entirely.

Closes #709.

Also, use apt-get instead of apt to avoid

> WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
