### PR TITLE
Fix build workflow docs job failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
     # there's some overlap with publish-pages.yml, but this one runs on pull
     # requests, doesn't publish, and runs more doc checks
     name: docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Git clone
@@ -116,8 +116,9 @@ jobs:
 
       - name: Install Python packages
         run: |
-          pip install -U -r requirements.txt hatchling hatch-vcs Sphinx \
-            sphinx-epytext sphinx-intl sphinx-rtd-theme sphinx-sitemap
+          pip install -U dnspython beautifulsoup4 requests \
+            hatchling hatch-vcs sphinx sphinx-epytext \
+            sphinx-intl sphinx-rtd-theme sphinx-sitemap
 
       - name: Build
         run: |


### PR DESCRIPTION
cryptography 39 is causing problems on Ubuntu 22.04 for Sphinx autosummary:

* AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms'

Stop installing pdfminer.six which is causing cryptography to be installed.