### PR TITLE
Delete oldest Docker images

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -43,3 +43,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Delete oldest Docker images
+        uses: actions/delete-package-versions@v4
+        with:
+          package-name: 'linkchecker'
+          package-type: 'container'
+          min-versions-to-keep: 20


### PR DESCRIPTION
Keep 20 most recent.

---

Seems like quite a big number? But a lot less than 89 and counting.
