### PR TITLE
Re-enable support for installing git archives

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+.git_archival.txt export-subst
 .gitattributes export-ignore  
 .gitignore export-ignore

--- a/doc/install.txt
+++ b/doc/install.txt
@@ -51,8 +51,6 @@ First, if you want application translations:
 Then:
 ``pip3 install git+https://github.com/linkchecker/linkchecker.git``
 
-N.B. git archive's cannot be used.
-
 .. _pip: https://pypi.org/project/pip/
 
 Setup for Windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,9 @@ dependencies = [
 
 [build-system]
 requires = [
-    "hatchling>=1.8.0",
+    "hatchling >= 1.8.0",
     "hatch-vcs",
+    "setuptools-scm >= 7.0.5",
 ]
 build-backend = "hatchling.build"
 

--- a/tools/hatch_build.py
+++ b/tools/hatch_build.py
@@ -15,6 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from pathlib import Path
+import re
 import shutil
 import subprocess
 
@@ -47,6 +48,18 @@ class CustomBuildHook(BuildHookInterface):
             if Path(*RELEASE_PY).is_file():
                 self.app.display_warning("_release.py already exists")
                 return
+
+            try:
+                git_archival = Path(".git_archival.txt").read_text()
+            except FileNotFoundError:
+                self.app.display_warning(".git_archival.txt does not exist")
+            else:
+                rematch = re.search(r"node-date: ((\d{4})-\d{2}-\d{2})", git_archival)
+                if rematch:
+                    committer_date = rematch.group(1)
+                    committer_year = rematch.group(2)
+                else:
+                    self.app.display_warning("node-date not substituted")
         else:
             if cp and cp.stdout:
                 committer_date = cp.stdout.strip()


### PR DESCRIPTION
setuptools_scm 7 includes git archive support. hatch-vcs currently requires a minimium of 6.4, ensure 7 is installed.