### PR TITLE
Pass CI to tox testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps =
 commands =
     !minreqs: pytest {posargs:--cov=linkcheck}
     minreqs: pytest {posargs:--cov=linkcheck -c pytest-minreqs.ini}
+passenv = CI
 setenv =
     LC_ALL=en_US.utf-8
 


### PR DESCRIPTION
Used since:
1cb7f3d78 ("Test on GitHub with httpbin from a container", 2023-06-05)