### PR TITLE
Make TextLogger message wrapping configurable

### DIFF
--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -252,6 +252,10 @@ text
     Valid encodings are listed in
     https://docs.python.org/library/codecs.html#standard-encodings.
     Default encoding is the system default locale encoding.
+**wraplength=**\ *NUMBER*
+    The number of characters at which to wrap each message line.
+    The default is 65.
+    Command line option: none
 *color\**
     Color settings for the various log parts, syntax is *color* or
     *type*\ **;**\ *color*. The *type* can be **bold**, **light**,

--- a/linkcheck/data/linkcheckerrc
+++ b/linkcheck/data/linkcheckerrc
@@ -50,6 +50,7 @@
 [text]
 #filename=linkchecker-out.txt
 #parts=all
+#wraplength=65
 # colors for the various parts, syntax is <color> or <type>;<color>
 # type can be bold, light, blink, invert
 # color can be default, black, red, green, yellow, blue, purple, cyan, white,

--- a/linkcheck/logger/text.py
+++ b/linkcheck/logger/text.py
@@ -19,7 +19,7 @@ The default text logger.
 import time
 
 from . import _Logger
-from .. import ansicolor, strformat, configuration
+from .. import ansicolor, log, strformat, configuration, LOG_CHECK
 
 
 class TextLogger(_Logger):
@@ -38,6 +38,7 @@ class TextLogger(_Logger):
 
     LoggerArgs = {
         "filename": "linkchecker-out.txt",
+        "wraplength": 65,
         'colorparent': "default",
         'colorurl': "default",
         'colorname': "default",
@@ -57,6 +58,11 @@ class TextLogger(_Logger):
         args = self.get_args(kwargs)
         super().__init__(**args)
         self.init_fileoutput(args)
+        try:
+            self.wraplength = int(args["wraplength"])
+        except ValueError:
+            self.wraplength = self.LoggerArgs["wraplength"]
+            log.warn(LOG_CHECK, _("Invalid value for wraplength. Using default."))
         self.colorparent = args["colorparent"]
         self.colorurl = args["colorurl"]
         self.colorname = args["colorname"]
@@ -191,7 +197,7 @@ class TextLogger(_Logger):
     def write_info(self, url_data):
         """Write url_data.info."""
         self.write(self.part("info") + self.spaces("info"))
-        self.writeln(self.wrap(url_data.info, 65), color=self.colorinfo)
+        self.writeln(self.wrap(url_data.info, self.wraplength), color=self.colorinfo)
 
     def write_modified(self, url_data):
         """Write url_data.modified."""
@@ -202,7 +208,7 @@ class TextLogger(_Logger):
         """Write url_data.warning."""
         self.write(self.part("warning") + self.spaces("warning"))
         warning_msgs = [f"[{tag}] {msg}" for tag, msg in url_data.warnings]
-        self.writeln(self.wrap(warning_msgs, 65), color=self.colorwarning)
+        self.writeln(self.wrap(warning_msgs, self.wraplength), color=self.colorwarning)
 
     def write_result(self, url_data):
         """Write url_data.result."""

--- a/tests/configuration/data/config0.ini
+++ b/tests/configuration/data/config0.ini
@@ -60,6 +60,7 @@ ignoreerrors=
 filename=imadoofus.txt
 PartS=Realurl
 encoding=utf-8
+wraplength=80
 colorparent=blink;red
 colorurl=blink;red
 colorname=blink;red

--- a/tests/configuration/test_config.py
+++ b/tests/configuration/test_config.py
@@ -119,6 +119,7 @@ class TestConfig(TestBase):
         self.assertEqual(config["text"]["filename"], "imadoofus.txt")
         self.assertEqual(config["text"]["parts"], ["realurl"])
         self.assertEqual(config["text"]["encoding"], "utf-8")
+        self.assertEqual(config["text"]["wraplength"], "80")
         self.assertEqual(config["text"]["colorparent"], "blink;red")
         self.assertEqual(config["text"]["colorurl"], "blink;red")
         self.assertEqual(config["text"]["colorname"], "blink;red")


### PR DESCRIPTION
New wraplength setting for text logger.

Closes: #729.
