### PR TITLE
Python 3.12 final is out, stop using -dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12-dev"
+          - "3.12"
         toxenv: [py]
         include:
           - python-version: "3.8"


### PR DESCRIPTION
Fixes the check-python-versions job in CI.