### PR TITLE
Use cryptography to generate certificate in TestHttps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py3{8,9,10,11,12}, minreqs
 
 [base]
 deps =
+    cryptography
     pyftpdlib
     parameterized
     pyopenssl


### PR DESCRIPTION
Replacing deprecated use of pyOpenSSL.

```
linkchecker/tests/checker/test_https.py:45: DeprecationWarning: X509Extension support in pyOpenSSL is deprecated. You should use the APIs in cryptography.
   [crypto.X509Extension(b"subjectAltName", False, b"DNS:localhost")])
```