### PR TITLE
[#785] Update requests to 2.25, required for Python 3.12

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,6 +1,6 @@
 # required:
 beautifulsoup4 == 4.8.1
-requests == 2.20.0
+requests == 2.25.0
 dnspython == 2.0.0
 # optional:
 argcomplete == 1.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # required:
 beautifulsoup4 >= 4.8.1
-requests >= 2.20
+requests >= 2.25
 dnspython >= 2.0
 # optional:
 argcomplete >= 1.8.1


### PR DESCRIPTION
In order to use Python 3.12, one needs `requests` to be at least at 2.25.
I checked that 

```
python -m venv --prompt "linkchecker" venv
source venv/bin/activate
pip install hatchling hatch-vcs -r requirements-min.txt
hatchling build --hooks-only
python --version
python -m linkcheck
```

works fine for all of Python versions 3.9.15, 3.10.6, 3.11.6, 3.12.0 and 3.12.1.
They work fine as well using `requirements.txt` instead of `requirements-min.txt`.