### PR TITLE
Adding ignoreddosprotection configuration flag

### DIFF
--- a/doc/man/de/linkcheckerrc.5
+++ b/doc/man/de/linkcheckerrc.5
@@ -100,6 +100,11 @@ To use values greater than 10, the HTTP server must return a
 The default is 10.
 Command line option: none
 .TP
+\fignoreddosprotection=\fP[\fB0\fP|\fB1\fP]
+Ignoriere den internen DDOS Schutz, der die maximale Anzahl der Anfragen auf
+6 pro Sekunde begrenzt.
+Mit Vorsicht zu verwenden!
+.TP
 \fBrobotstxt=\fP[\fB0\fP|\fB1\fP]
 When using http, fetch robots.txt, and confirm whether each URL should
 be accessed before checking.

--- a/doc/man/en/linkcheckerrc.5
+++ b/doc/man/en/linkcheckerrc.5
@@ -127,6 +127,11 @@ To use values greater than 10, the HTTP server must return a
 The default is 10.
 Command line option: none
 .TP
+\fignoreddosprotection=\fP[\fB0\fP|\fB1\fP]
+Ignore the internal DDOS protection which limits the maximum number of requests
+to 6 per second.
+Use with caution!
+.TP
 \fBrobotstxt=\fP[\fB0\fP|\fB1\fP]
 When using http, fetch robots.txt, and confirm whether each URL should
 be accessed before checking.

--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -90,6 +90,10 @@ checking
     "LinkChecker" response header.
     The default is 10.
     Command line option: none
+**ignoreddosprotection=**\ [**0**\ \|\ **1**]
+    Ignore the internal DDOS protection which limits the maximum number of requests
+    to 6 per second.
+    Use with caution!
 **robotstxt=**\ [**0**\ \|\ **1**]
     When using http, fetch robots.txt, and confirm whether each URL should
     be accessed before checking.

--- a/linkcheck/configuration/__init__.py
+++ b/linkcheck/configuration/__init__.py
@@ -148,6 +148,7 @@ class Configuration(dict):
         self["maxnumurls"] = None
         self["maxrunseconds"] = None
         self["maxrequestspersecond"] = 10
+        self["ignoreddosprotection"] = False
         self["maxhttpredirects"] = 10
         self["sslverify"] = True
         self["threads"] = 10

--- a/linkcheck/configuration/confparse.py
+++ b/linkcheck/configuration/confparse.py
@@ -199,6 +199,7 @@ class LCConfigParser(RawConfigParser):
         self.read_int_option(section, "recursionlevel", min=-1)
         self.read_string_option(section, "useragent")
         self.read_float_option(section, "maxrequestspersecond", min=0.001)
+        self.read_boolean_option(section, "ignoreddosprotection")
         self.read_int_option(section, "maxnumurls", min=0)
         self.read_int_option(section, "maxfilesizeparse", min=1)
         self.read_int_option(section, "maxfilesizedownload", min=1)

--- a/linkcheck/data/linkcheckerrc
+++ b/linkcheck/data/linkcheckerrc
@@ -181,6 +181,8 @@
 #maxnumurls=153
 # Maximum number of requests per second to one host.
 #maxrequestspersecond=10
+# Ignore the internal DDOS protection
+#ignoreddosprotection=0
 # Respect the instructions in any robots.txt files
 #robotstxt=1
 # Allowed URL schemes as a comma-separated list. Example:

--- a/linkcheck/director/aggregator.py
+++ b/linkcheck/director/aggregator.py
@@ -77,6 +77,7 @@ class Aggregate:
         requests_per_second = config["maxrequestspersecond"]
         self.wait_time_min = 1.0 / requests_per_second
         self.wait_time_max = 6 * self.wait_time_min
+        self.ignoreddosprotection = config["ignoreddosprotection"]
         self.downloaded_bytes = 0
 
     def visit_loginurl(self):
@@ -161,7 +162,7 @@ class Aggregate:
                 wait = due_time - t
                 time.sleep(wait)
                 t = time.time()
-        if host in self.maxrated:
+        if host in self.maxrated or self.ignoreddosprotection:
             wait_time_min, wait_time_max = self.wait_time_min, self.wait_time_max
         else:
             wait_time_min = max(self.wait_time_min, self.wait_time_min_default)

--- a/tests/configuration/data/config0.ini
+++ b/tests/configuration/data/config0.ini
@@ -12,6 +12,7 @@ localwebroot=foo
 sslverify=/path/to/cacerts.crt
 maxnumurls=1000
 maxrequestspersecond=0.1
+ignoreddosprotection=0
 maxrunseconds=1
 maxfilesizeparse=100
 maxfilesizedownload=100

--- a/tests/configuration/test_config.py
+++ b/tests/configuration/test_config.py
@@ -55,6 +55,7 @@ class TestConfig(TestBase):
         self.assertEqual(config["sslverify"], "/path/to/cacerts.crt")
         self.assertEqual(config["maxnumurls"], 1000)
         self.assertEqual(config["maxrequestspersecond"], 0.1)
+        self.assertEqual(config["ignoreddosprotection"], 0)
         self.assertEqual(config["maxrunseconds"], 1)
         self.assertEqual(config["maxfilesizeparse"], 100)
         self.assertEqual(config["maxfilesizedownload"], 100)


### PR DESCRIPTION
This PR adds the following configuration flag:

ignoreddosprotection - ignore a missing 'LinkChecker' response header if the user requests more than 6 requests per second.

Help needed: I don't know how to create the `doc/i18n/*.po(|t)` files - they seem
to be auto-generated, but I don't see how to do that.

See #778 