### PR TITLE
Fix test_ignoreerrors test_internet failure

### DIFF
--- a/tests/checker/test_ignoreerrors.py
+++ b/tests/checker/test_ignoreerrors.py
@@ -23,7 +23,7 @@ from tests import need_network
 from . import LinkCheckTest
 
 
-class TestFile(LinkCheckTest):
+class TestIgnoreErrors(LinkCheckTest):
     """
     Test whether ignoring of errors per URL works.
     """


### PR DESCRIPTION
example.com is returning HTTP code 500.

Rename test_ignoreerrors.TestFile
