### PR TITLE
Use actions/deploy-pages to publish to GitHub Pages

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -42,9 +42,26 @@ jobs:
             python3 -m hatchling build -t sdist --hooks-only
             make -C doc html
 
-      - name: Publish
-        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./doc/html
-          commit_message: ${{ github.event.head_commit.message }}
+          path: "doc/html"
+
+
+  deploy:
+
+    needs: run
+
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
gh-pages branch is no longer used.