### PR TITLE
fix: header check should be case-insensitive

### DIFF
--- a/linkcheck/checker/httpurl.py
+++ b/linkcheck/checker/httpurl.py
@@ -177,7 +177,8 @@ class HttpUrl(internpaturl.InternPatternUrl):
         log.debug(LOG_CHECK, "Response headers %s", self.headers)
         self.set_encoding(self.url_connection.encoding)
         log.debug(LOG_CHECK, "Response encoding %s", self.content_encoding)
-        if "LinkChecker" in self.headers:
+        header_lowercase = {k.lower(): v for k, v in self.headers.items()}
+        if "linkchecker" in header_lowercase:
             self.aggregate.set_maxrated_for_host(self.urlparts[1])
         self._add_ssl_info()
 


### PR DESCRIPTION
HTTP headers are not case sensitive. This becomes an issue when using Caddy to host pages to be checked by the linkchecker project. Caddy will automatically lowercase header names, which results in checker throughput being limited.

This PR modifies the check for the `LinkChecker` header to perform the check case-insensitively.

>   Just as in HTTP/1.x, header field names are strings of ASCII
>   characters that are compared in a case-insensitive fashion.  However,
>   header field names MUST be converted to lowercase prior to their
>   encoding in HTTP/2.  A request or response containing uppercase
>   header field names MUST be treated as malformed

https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2