### PR TITLE
Remove ref-names from .git_archival.txt

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,4 +1,3 @@
 node: $Format:%H$
 node-date: $Format:%cI$
 describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
-ref-names: $Format:%D$


### PR DESCRIPTION
Can cause differences in the archive generated for a tagged commit when subsequent commits have been made to the repository.