### PR TITLE
Fix pylint errors (false positives)

### DIFF
--- a/linkcheck/ansicolor.py
+++ b/linkcheck/ansicolor.py
@@ -159,6 +159,10 @@ if os.name == 'nt':
         Cyan: colorama.CYAN,
         White: colorama.GREY,
     }
+else:
+    WinColor = {
+        None: None,
+    }
 
 # pc speaker beep escape code
 Beep = "\007"

--- a/linkcheck/plugins/locationinfo.py
+++ b/linkcheck/plugins/locationinfo.py
@@ -69,6 +69,7 @@ def get_geoip_dat():
 # try importing both the C-library GeoIP and the pure-python pygeoip
 geoip_dat = get_geoip_dat()
 geoip = None
+geoip_error = None
 if geoip_dat:
     try:
         import GeoIP


### PR DESCRIPTION
The errors were

    ************* Module linkcheck.ansicolor
    linkcheck/ansicolor.py:190:21: E0606: Possibly using variable 'WinColor' before assignment (possibly-used-before-assignment)
    ************* Module linkcheck.plugins.locationinfo
    linkcheck/plugins/locationinfo.py:107:12: E0606: Possibly using variable 'geoip_error' before assignment (possibly-used-before-assignment)

and while it's true that the variables (WinColor, geoip_error) are assigned conditionally, their use is protected (indirectly) by the same conditionals.