### PR TITLE
Avoid Coveralls upload failure because build was closed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,18 @@ jobs:
 
       - name: Report to coveralls
         uses: coverallsapp/github-action@f350da2c033043742f89e8c0b7b5145a1616da6d  # v2.1.2
+        with:
+          parallel: true
+          flag-name: run-${{ matrix.python-version }}
+
+  finish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close coveralls parallel build
+        uses: coverallsapp/github-action@f350da2c033043742f89e8c0b7b5145a1616da6d  # v2.1.2
+        with:
+          parallel-finished: true
 
   docs:
     # there's some overlap with publish-pages.yml, but this one runs on pull


### PR DESCRIPTION
Error: Unprocessable Entity
Can't add a job to a build that is already closed. See docs.coveralls.io/parallel-builds

---

Haven't seen this here - yet. But seems easy and prudent to avoid.
