### PR TITLE
Add cryptography to tool.hatch.envs.test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ version_scheme = "post-release"
 
 [tool.hatch.envs.test]
 dependencies = [
+    "cryptography",
     "parameterized",
     "pdfminer.six",
     "pyftpdlib",


### PR DESCRIPTION
Needed since:
219c17aa6 ("Use cryptography to generate certificate in TestHttps", 2023-11-07)