### PR TITLE
Enable ignorewarningsforurls for AnchorCheck

### DIFF
--- a/doc/man/en/linkchecker.1
+++ b/doc/man/en/linkchecker.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "LINKCHECKER" "1" "August 27, 2024" "10.4.0.post49+g7cf5037e" "LinkChecker"
+.TH "LINKCHECKER" "1" "September 10, 2024" "10.5.0.post0+gdae72c8b.d20240910113942" "LinkChecker"
 .SH NAME
 linkchecker \- command line client to check HTML documents and websites for broken links
 .SH SYNOPSIS

--- a/doc/man/en/linkcheckerrc.5
+++ b/doc/man/en/linkcheckerrc.5
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "LINKCHECKERRC" "5" "August 27, 2024" "10.4.0.post49+g7cf5037e" "LinkChecker"
+.TH "LINKCHECKERRC" "5" "September 10, 2024" "10.5.0.post0+gdae72c8b.d20240910113942" "LinkChecker"
 .SH NAME
 linkcheckerrc \- configuration file for LinkChecker
 .SH DESCRIPTION
@@ -178,6 +178,7 @@ Example:
 [filtering]
 ignorewarningsforurls=
   ^https://redirected\e.example\e.com ^http\-redirected
+  ^https://github.com ^url\-anchorcheck\-anchor\-not\-found
 .ft P
 .fi
 .UNINDENT
@@ -739,6 +740,10 @@ Redirected to a different URL.
 .TP
 \fBmail\-no\-mx\-host\fP
 The mail MX host could not be found.
+.TP
+\fBurl\-anchorcheck\-anchor\-not\-found\fP
+The URL points to an anchor which could not be found in the target page.
+Either the anchor is incorrect or it is generated in JavaScript.
 .TP
 \fBurl\-content\-size\-zero\fP
 The URL content size is zero.

--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -134,6 +134,7 @@ filtering
     [filtering]
     ignorewarningsforurls=
       ^https://redirected\.example\.com ^http-redirected
+      ^https://github.com ^url-anchorcheck-anchor-not-found
 
 **internlinks=**\ *REGEX*
     Regular expression to add more URLs recognized as internal links.
@@ -613,6 +614,9 @@ The following warnings are recognized by **ignorewarnings** and
     Redirected to a different URL.
 **mail-no-mx-host**
     The mail MX host could not be found.
+**url-anchorcheck-anchor-not-found**
+    The URL points to an anchor which could not be found in the target page.
+    Either the anchor is incorrect or it is generated in JavaScript.
 **url-content-size-zero**
     The URL content size is zero.
 **url-content-too-large**

--- a/linkcheck/checker/const.py
+++ b/linkcheck/checker/const.py
@@ -75,6 +75,7 @@ ExcList = ExcCacheList + ExcNoCacheList
 URL_MAX_LENGTH = 2047
 
 # the warnings
+WARN_URL_ANCHORCHECK_ANCHOR_NOT_FOUND = "url-anchorcheck-anchor-not-found"
 WARN_URL_EFFECTIVE_URL = "url-effective-url"
 WARN_URL_ERROR_GETTING_CONTENT = "url-error-getting-content"
 WARN_URL_CONTENT_SIZE_TOO_LARGE = "url-content-too-large"
@@ -96,6 +97,10 @@ WARN_XML_PARSE_ERROR = "xml-parse-error"
 
 # registered warnings
 Warnings = {
+    WARN_URL_ANCHORCHECK_ANCHOR_NOT_FOUND: _(
+        "The URL points to an anchor which could not be found in the target page."
+        "Either the anchor is incorrect or it is generated in JavaScript."
+    ),
     WARN_URL_EFFECTIVE_URL: _("The effective URL is different from the original."),
     WARN_URL_ERROR_GETTING_CONTENT: _("Could not get the content of the URL."),
     WARN_URL_CONTENT_SIZE_TOO_LARGE: _("The URL content size is too large."),

--- a/linkcheck/plugins/anchorcheck.py
+++ b/linkcheck/plugins/anchorcheck.py
@@ -21,6 +21,7 @@ import urllib.parse
 from . import _ContentPlugin
 from .. import log, LOG_PLUGIN
 from ..htmlutil import linkparse
+from ..checker.const import WARN_URL_ANCHORCHECK_ANCHOR_NOT_FOUND
 
 
 class AnchorCheck(_ContentPlugin):
@@ -70,4 +71,4 @@ class UrlAnchorCheck:
             _("Anchor `%(name)s' (decoded: `%(decoded)s') not found.") % args,
             _("Available anchors: %(anchors)s.") % args,
         )
-        url_data.add_warning(msg)
+        url_data.add_warning(msg, tag=WARN_URL_ANCHORCHECK_ANCHOR_NOT_FOUND)


### PR DESCRIPTION
Some websites, such as GitHub, generate some of the anchors in JavaScript. As a result, AnchorCheck tends to warn of missing anchors.

This PR introduces the `url-anchorcheck-anchor-not-found` warning and changes AnchorCheck so it tags all its warnings. This enables the user to use the recently introduced `ignorewarningsforurls` feature to silence AnchorCheck for selected URLs.