### PR TITLE
Update unknownurl.py: ignore Litecoin URL schemes

### DIFF
--- a/linkcheck/checker/unknownurl.py
+++ b/linkcheck/checker/unknownurl.py
@@ -248,8 +248,10 @@ ignored_schemes_provisional = r"""
 |lbry       # lbry
 |ldaps      # ldaps
 |lid        # lid
+|litecoin   # Litecoin
 |lorawan    # lorawan
 |lpa        # lpa
+|ltclightning # Litecoin lighting
 |lvlt       # lvlt
 |machineProvisioningProgressReporter # Windows Autopilot Modern Device Management status updates
 |magnet     # magnet


### PR DESCRIPTION
https://litecoin.info/docs/key-concepts/uri-scheme

These URLs are used on f-droid.org, see the "Donate" section:
https://f-droid.org/packages/app.organicmaps/

Here is an example error:
https://gitlab.com/fdroid/fdroid-website/-/jobs/8420894335