### PR TITLE
Support <source srcset=...>

### DIFF
--- a/linkcheck/htmlutil/linkparse.py
+++ b/linkcheck/htmlutil/linkparse.py
@@ -53,7 +53,7 @@ LinkTags = {
     'object': ['classid', 'data', 'archive', 'usemap', 'codebase'],
     'q': ['cite'],
     'script': ['src'],
-    'source': ['src'],  # HTML5
+    'source': ['src', 'srcset'],  # HTML5
     'table': ['background'],
     'td': ['background'],
     'th': ['background'],

--- a/tests/test_linkparser.py
+++ b/tests/test_linkparser.py
@@ -96,6 +96,17 @@ class TestLinkparser(TestBase):
         url = "data:image/vnd.microsoft.icon,000001000200"
         self._test_one_link(content, url)
 
+    def test_source_srcset_parsing(self):
+        content = '<source srcset="%s 1x">'
+        url = "imagesmall.jpg"
+        self._test_one_link(content % url, url)
+        content = '<img srcset="imagesmall.jpg 1x,">'
+        url = "imagesmall.jpg"
+        self._test_one_link(content, url)
+        content = '<img srcset="data:image/vnd.microsoft.icon,000001000200">'
+        url = "data:image/vnd.microsoft.icon,000001000200"
+        self._test_one_link(content, url)
+
     def test_itemtype_parsing(self):
         content = '<div itemtype="%s">'
         url = "http://example.org/Movie"


### PR DESCRIPTION
The `<source>` element can have a `srcset=` attribute with links that should be checked.