### PR TITLE
Disable VirusCheck plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,35 +41,7 @@ jobs:
       - name: Install OS dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clamav-daemon geoip-database libgeoip-dev gettext
-
-      - name: Make ClamAV cache directory writeable for cache action
-        run: |
-          sudo chown -R runner:docker /var/lib/clamav
-
-      - name: ClamAV cache
-        id: cache-clamav
-        uses: actions/cache@v4
-        with:
-          path: /var/lib/clamav
-          key: clamav-v1
-
-      - name: Restore ClamAV directory ownership
-        run: |
-          sudo chown -R clamav:clamav /var/lib/clamav
-
-      - name: Restart ClamAV Daemon
-        if: ${{ steps.cache-clamav.outputs.cache-hit == 'true' }}
-        run: |
-          sudo service clamav-daemon restart
-
-      - name: Download the ClamAV signature database
-        if: ${{ steps.cache-clamav.outputs.cache-hit != 'true' }}
-        run: |
-          sudo service clamav-freshclam stop
-          sudo freshclam
-          sudo service clamav-daemon restart
-          sudo service clamav-daemon status
+          sudo apt-get install -y geoip-database libgeoip-dev gettext
 
       - name: Git clone
         uses: actions/checkout@v4
@@ -97,10 +69,6 @@ jobs:
           python -m pip install -U pip
           python -m pip install -U hatchling hatch-vcs polib
           python -m pip install -U tox coverage
-
-      - name: Wait for ClamAV to be ready
-        run: |
-          while ! test -S /run/clamav/clamd.ctl; do printf "."; sleep 1; done
 
       - name: Run tests
         run: |

--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -569,6 +569,10 @@ daemon must be installed.
 **clamavconf=**\ *filename*
     Filename of **clamd.conf** config file.
 
+.. note::
+
+    The VirusCheck plugin does not support ClamAV >= 1.0 and is disabled.
+
 PdfParser
 ^^^^^^^^^
 

--- a/linkcheck/plugins/viruscheck.py
+++ b/linkcheck/plugins/viruscheck.py
@@ -34,9 +34,13 @@ class VirusCheck(_ContentPlugin):
         self.clamav_conf = get_clamav_conf(canonical_clamav_conf())
         if not self.clamav_conf:
             log.warn(LOG_PLUGIN, "clamav daemon not found for VirusCheck plugin")
+        log.warn(
+            LOG_PLUGIN, _("VirusCheck plugin does not support ClamAV >= 1.0.")
+        )
 
     def applies_to(self, url_data):
         """Check for clamav and extern."""
+        return False  # XXX Plugin disabled
         return self.clamav_conf and not url_data.extern[0]
 
     def check(self, url_data):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -160,7 +160,7 @@ def has_clamav():
     return False
 
 
-need_clamav = _need_func(has_clamav, "ClamAV")
+need_clamav = _need_func(has_clamav, "ClamAV", False)  # XXX Plugin disabled
 
 
 @lru_cache(1)


### PR DESCRIPTION
Not compatible with ClamAV >= 1.0.

---

Breaking CI. On the cards anyway, from memory ClamAV 0.1 engine is no longer supported and access to signatures was going to stop in September (maybe it has come early).
