### PR TITLE
Revert "Add missing "not" to `ignore` description"

### DIFF
--- a/doc/src/man/linkcheckerrc.rst
+++ b/doc/src/man/linkcheckerrc.rst
@@ -107,7 +107,7 @@ filtering
 ^^^^^^^^^
 
 **ignore=**\ *REGEX* (`MULTILINE`_)
-    Only check syntax of URLs not matching the given regular expressions.
+    Only check syntax of URLs matching the given regular expressions.
     Command line option: :option:`--ignore-url`
 **ignorewarnings=**\ *NAME*\ [**,**\ *NAME*...]
     Ignore the comma-separated list of warnings. See `WARNINGS`_ for

--- a/linkcheck/command/arg_parser.py
+++ b/linkcheck/command/arg_parser.py
@@ -367,7 +367,7 @@ class ArgParser(LCArgumentParser):
             metavar="REGEX",
             dest="externstrict",
             help=_(
-                "Only check syntax of URLs not matching the given regular expression.\n"
+                "Only check syntax of URLs matching the given regular expression.\n"
                 "This option can be given multiple times."
             ),
         )


### PR DESCRIPTION
This reverts commit f87d149058a43927d78b4dcea647bc2794957d47.