### PR TITLE
Ignore pylint 4.0.1 E0606 in locationinfo

### DIFF
--- a/linkcheck/plugins/locationinfo.py
+++ b/linkcheck/plugins/locationinfo.py
@@ -104,6 +104,7 @@ def get_location(host):
         # no geoip available
         return None
     try:
+        # pylint: disable-next=possibly-used-before-assignment
         record = get_geoip_record(host)
     except (geoip_error, OSError):
         log.debug(LOG_PLUGIN, "Geoip error for %r", host, exception=True)


### PR DESCRIPTION
************* Module linkcheck.plugins.locationinfo linkcheck/plugins/locationinfo.py:107:17: E0606: Possibly using variable 'get_geoip_record' before assignment (possibly-used-before-assignment)