### PR TITLE
Allow for urlset starting further into a sitemap

### DIFF
--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -102,6 +102,7 @@ class UrlBase:
         "text/plain+chromium": "chromium",
         "application/x-plist+safari": "safari",
         "text/vnd.wap.wml": "wml",
+        "application/xml": "sitemap",
         "application/xml+sitemap": "sitemap",
         "application/xml+sitemapindex": "sitemapindex",
         "application/pdf": "pdf",

--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -102,7 +102,6 @@ class UrlBase:
         "text/plain+chromium": "chromium",
         "application/x-plist+safari": "safari",
         "text/vnd.wap.wml": "wml",
-        "application/xml": "sitemap",
         "application/xml+sitemap": "sitemap",
         "application/xml+sitemapindex": "sitemapindex",
         "application/pdf": "pdf",

--- a/linkcheck/mimeutil.py
+++ b/linkcheck/mimeutil.py
@@ -92,7 +92,7 @@ def guess_mimetype_read(read):
     """Try to read some content and do a poor man's file(1)."""
     mime = None
     try:
-        data = read()[:70]
+        data = read()[:255]
     except Exception:
         pass
     else:


### PR DESCRIPTION
### Problem/Motivation

Hi, I was testing and evaluating linkchecker and its support for parsing a provided sitemap.xml URL.

When using linkchecker with a URL to a sitemap.xml, if the server responds with `application/xml`, then linkchecker will report the URL is not parseable. This is a follow-up to #47.

Example output snippet:

```sh
linkchecker --verbose -f .linkcheckerrc https://example.com/sitemap.xml
LinkChecker 10.6.0
Copyright (C) 2000-2016 Bastian Kleineidam, 2010-2025 LinkChecker Authors
LinkChecker comes with ABSOLUTELY NO WARRANTY!
This is free software, and you are welcome to redistribute it under
certain conditions. Look at the file `COPYING' within this distribution.
Read the documentation at https://linkchecker.github.io/linkchecker/
Write comments and bugs to https://github.com/linkchecker/linkchecker/issues

Start checking at 2026-07-02 12:31:50-004

URL        `https://example.com/sitemap.xml`
Real URL   https://example.com/sitemap.xml
Check time 0.028 seconds                                                                                                                                                                                                             
D/L time   0.000 seconds
Size       14.24KB
Warning    [url-content-type-unparseable] The URL with content
           type 'application/xml' is not parseable.                                                                                                                                                                                  
Result     Valid: 200 OK

Statistics:
Downloaded: 14.24KB.
Content types: 0 image, 0 text, 0 video, 0 audio, 1 application, 0 mail and 0 other.
URL lengths: min=36, max=36, avg=36.

That's it. 1 link in 1 URL checked. 1 warning found. 0 errors found.
Stopped checking at 2026-07-02 12:31:51-004 (1 seconds)
```

### Proposed resolution

Increases bytes read in `guess_mimetype_read` from 70 to 255 to account for some extra lines.

### Questions

- Is increasing the bytes read a good idea? Arbitrarily increasing the string length to pass into regex checking might cause performance issues?

I tried searching for a place where I could add a test where the server would respond with the various content mime types, but I think that is beyond my abilities as I am not familiar with Python. I don't think the tests cover all the content mime type cases. If this is necessary, please do fork and create a new pull request.