### PR TITLE
Replace deprecated OpenSSL.crypto.X509.get_subject()

### DIFF
--- a/linkcheck/httputil.py
+++ b/linkcheck/httputil.py
@@ -18,13 +18,15 @@ def x509_to_dict(x509):
     """Parse a x509 pyopenssl object to a dictionary with keys
     subject, subjectAltName and optional notAfter.
     """
-    from cryptography.x509 import DNSName, SubjectAlternativeName
+    from cryptography.x509 import DNSName, NameOID, SubjectAlternativeName
 
     crypto_cert = x509.to_cryptography()
     ext = crypto_cert.extensions.get_extension_for_class(SubjectAlternativeName)
 
     res = {
-        'subject': ((('commonName', x509.get_subject().CN),),),
+        'subject': [
+            (('commonName', x.value),) for x in
+            crypto_cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)],
         'subjectAltName': [
             ('DNS', value) for value in ext.value.get_values_for_type(DNSName)]
     }

--- a/tests/checker/test_https.py
+++ b/tests/checker/test_https.py
@@ -96,5 +96,9 @@ class TestHttps(HttpsServerTest):
         with open(get_file("https_cert.pem"), "rb") as f:
             cert = crypto.load_certificate(crypto.FILETYPE_PEM, f.read())
         self.assertEqual(
+            httputil.x509_to_dict(cert)["subject"],
+            [(('commonName', "linkchecker.github.io"),)]
+        )
+        self.assertEqual(
             httputil.x509_to_dict(cert)["notAfter"], "Jan 02 03:04:05 2119 GMT"
         )


### PR DESCRIPTION
Deprecated since pyOpenSSL 26.3.0.

```
tests/checker/test_https.py::TestHttps::test_x509_to_dict
  linkcheck/httputil.py:27: DeprecationWarning: X509.get_subject is deprecated. You should use cryptography's X.509 APIs instead.
    'subject': ((('commonName', x509.get_subject().CN),),),
```
