### PR TITLE
Fix TypeError when a warning is added before the URL is built

### DIFF
--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -391,7 +391,7 @@ class UrlBase:
             log.debug(LOG_CHECK,
                       "ignorewarningsforurl: considering '%s, %s'",
                       url_regex, name_regex)
-            if not url_regex.search(self.url):
+            if not url_regex.search(self.url or ""):
                 continue
             log.debug(LOG_CHECK, "ignorewarningsforurl: URL matches '%s'", self.url)
             if not name_regex.search(tag):

--- a/tests/checker/test_ignorewarnings.py
+++ b/tests/checker/test_ignorewarnings.py
@@ -18,6 +18,9 @@ Test ignoring of warnings.
 """
 
 from re import compile as re_compile
+from types import SimpleNamespace
+
+from linkcheck.checker.urlbase import UrlBase
 
 from . import LinkCheckTest
 
@@ -58,3 +61,24 @@ class TestIgnoreWarnings(LinkCheckTest):
             ]
         }
         self.file_test("base_ignorewarnings.html", confargs=confargs)
+
+
+class TestIgnoreWarningsBeforeUrlBuilt(LinkCheckTest):
+    """
+    Test that warnings added before the real URL is built do not crash.
+    """
+
+    def test_warning_before_url_is_built(self):
+        """A warning can be added while self.url is still None."""
+        url_data = UrlBase.__new__(UrlBase)
+        url_data.reset()
+        url_data.aggregate = SimpleNamespace(
+            config={
+                "ignorewarnings": [],
+                "ignorewarningsforurls": [
+                    (re_compile("^https://youtu.be"), re_compile("url-whitespace"))
+                ],
+            }
+        )
+        self.assertIsNone(url_data.url)
+        self.assertFalse(url_data.should_ignore_warning("url-whitespace"))


### PR DESCRIPTION
Closes #859

`should_ignore_warning()` passes `self.url` straight to the `ignorewarningsforurls` regex, but warnings can be added from `UrlBase.__init__` (e.g. `url-whitespace` for a href containing spaces) while `self.url` is still `None`, so the regex raised `TypeError: expected string or bytes-like object` and aborted the whole run with an internal error. Matching against `self.url or ""` uses the same idiom already applied when building the log entry.

A regression test adds a warning while `self.url` is None; it fails with the reported TypeError without the fix.