### PR TITLE
Tag oversized content with url-content-too-large

### DIFF
--- a/linkcheck/__init__.py
+++ b/linkcheck/__init__.py
@@ -52,6 +52,13 @@ class LinkCheckerError(Exception):
     pass
 
 
+class LinkCheckerContentTooLargeError(LinkCheckerError):
+    """Exception to be raised when the URL content exceeds the configured
+    maximum download size."""
+
+    pass
+
+
 class LinkCheckerInterrupt(Exception):
     """Used for testing."""
 

--- a/linkcheck/checker/httpurl.py
+++ b/linkcheck/checker/httpurl.py
@@ -38,7 +38,7 @@ from .. import (
     LOG_CHECK,
     mimeutil,
     url as urlutil,
-    LinkCheckerError,
+    LinkCheckerContentTooLargeError,
     httputil,
 )
 from . import internpaturl
@@ -345,7 +345,7 @@ class HttpUrl(internpaturl.InternPatternUrl):
         buf = BytesIO()
         for data in self.url_connection.iter_content(chunk_size=self.ReadChunkBytes):
             if buf.tell() + len(data) > maxbytes:
-                raise LinkCheckerError(_("File size too large"))
+                raise LinkCheckerContentTooLargeError(_("File size too large"))
             buf.write(data)
         return buf.getvalue()
 

--- a/linkcheck/checker/urlbase.py
+++ b/linkcheck/checker/urlbase.py
@@ -32,6 +32,7 @@ from .. import (
     log,
     LOG_CHECK,
     strformat,
+    LinkCheckerContentTooLargeError,
     LinkCheckerError,
     url as urlutil,
     trace,
@@ -608,6 +609,12 @@ class UrlBase:
                     self.aggregate.plugin_manager.run_content_plugins(self)
                 if self.allows_recursion():
                     return True
+            except LinkCheckerContentTooLargeError:
+                value = self.handle_exception()
+                self.add_warning(
+                    _("could not get content: %(msg)s") % {"msg": value},
+                    tag=WARN_URL_CONTENT_SIZE_TOO_LARGE,
+                )
             except tuple(ExcList):
                 value = self.handle_exception()
                 self.add_warning(
@@ -797,7 +804,7 @@ class UrlBase:
         data = self.read_content_chunk()
         while data:
             if buf.tell() + len(data) > self.aggregate.config["maxfilesizedownload"]:
-                raise LinkCheckerError(_("File size too large"))
+                raise LinkCheckerContentTooLargeError(_("File size too large"))
             buf.write(data)
             data = self.read_content_chunk()
         return buf.getvalue()

--- a/tests/checker/test_content_too_large.py
+++ b/tests/checker/test_content_too_large.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2024 LinkChecker Authors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Test the warning tag used when content exceeds maxfilesizedownload.
+"""
+from unittest import mock
+
+from linkcheck.checker.const import WARN_URL_CONTENT_SIZE_TOO_LARGE
+from linkcheck.checker.urlbase import UrlBase
+from .. import TestBase
+
+
+class TestContentTooLarge(TestBase):
+    """
+    Exceeding maxfilesizedownload is not an error getting the content,
+    so it must be tagged url-content-too-large and therefore be
+    ignorable with ignorewarnings.
+    """
+
+    def get_url_data(self, maxfilesizedownload):
+        url_data = UrlBase.__new__(UrlBase)
+        url_data.do_check_content = True
+        url_data.valid = True
+        url_data.warnings = []
+        url_data.info = []
+        url_data.size = 0
+        url_data.dltime = 0
+        url_data.data = None
+        url_data.caching = True
+        url_data.url = "http://example.org/huge.html"
+        url_data.aggregate = mock.Mock()
+        url_data.aggregate.config = {
+            "maxfilesizedownload": maxfilesizedownload,
+        }
+        url_data.should_ignore_warning = lambda tag: False
+        url_data.can_get_content = lambda: True
+        url_data.allows_recursion = lambda: False
+        url_data.url_connection = mock.Mock()
+        url_data.url_connection.read.side_effect = [b"x" * 100, b""]
+        url_data.aggregate.plugin_manager.run_content_plugins.side_effect = (
+            lambda url_data: url_data.get_raw_content()
+        )
+        return url_data
+
+    def test_too_large_content_warning_tag(self):
+        url_data = self.get_url_data(5)
+        self.assertFalse(url_data.check_content())
+        self.assertEqual(len(url_data.warnings), 1)
+        self.assertEqual(url_data.warnings[0][0], WARN_URL_CONTENT_SIZE_TOO_LARGE)


### PR DESCRIPTION
Closes #853

Hitting `maxfilesizedownload` raised a plain `LinkCheckerError`, which `check_content()` caught through `ExcList` and reported as `url-error-getting-content` — so `ignorewarnings=url-content-too-large` never suppressed it, even though the request itself succeeded (`Valid: 200 OK`). The size checks now raise a dedicated `LinkCheckerContentTooLargeError` that `check_content()` catches separately and tags `url-content-too-large`.

New `tests/checker/test_content_too_large.py` fails on master with `'url-error-getting-content' != 'url-content-too-large'` and passes with the fix.
